### PR TITLE
Changed repository to write documentation to biocro/BioCro-documentation

### DIFF
--- a/.github/workflows/automatically-call-document.yml
+++ b/.github/workflows/automatically-call-document.yml
@@ -6,11 +6,8 @@ name: Automatically generate documentation
 
 on:
   push:
-    branches:
-      - main
-
     tags:
-      - '*'
+      - v*.*
 
   # This event creates an artifact for download but does not write to
   # the BioCro documentation repository:

--- a/.github/workflows/automatically-call-document.yml
+++ b/.github/workflows/automatically-call-document.yml
@@ -5,9 +5,8 @@ name: Automatically generate documentation
 # generated" section of the Bookdown book.
 
 on:
-  push:
-    tags:
-      - v*.*
+  release:
+    types: [published]
 
   # This event creates an artifact for download but does not write to
   # the BioCro documentation repository:

--- a/.github/workflows/automatically-call-document.yml
+++ b/.github/workflows/automatically-call-document.yml
@@ -7,7 +7,7 @@ name: Automatically generate documentation
 on:
   push:
     branches:
-      - master
+      - main
 
     tags:
       - '*'

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -154,6 +154,10 @@ jobs:
         # (Re)create target documentation directory:
         mkdir -p $VERSION
 
+        # Symlink "latest" to the new version:
+        rm -f latest
+        ln -s $VERSION latest
+
         # Copy the respective documentation into them:
 
         if [[ ${{ inputs.pkgdown-build }} == true ]]

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -50,7 +50,7 @@ on:
 
 env:
   # The documentation repository:
-  PUBLISH_TO: "ebimodeling/biocro-documentation"
+  PUBLISH_TO: "biocro/BioCro-documentation"
   # Relative path from the GitHub workspace directory to the directory
   # where the documentation repository will be checked out:
   BIOCRO_DOCUMENTATION_ROOT: biocro_documentation_root

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: BioCro
-Version: 3.0.0
+Version: 3.0.1
 Date: 2023-10-30
 Title: Modular Crop Growth Simulations
 Description: A cross-platform representation of models as sets of equations

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,9 +23,12 @@ for the next release.
 - This version pertains only to the GitHub documentation workflow.  It
   changes the publication location to the
   `biocro/BioCro-documentation` repository, and it changes the
-  triggers of the workflow so that automatic publication happens only
-  when a version tag matching the pattern 'v*.*' is pushed to the
-  repository.
+  triggers of the workflow so that automatic publication happens when
+  a new release is published.  Additionally, a symlink is created to
+  link the URL
+  https://biocro.github.io/BioCro-documentation/latest/pkgdown/ to
+  https://biocro.github.io/BioCro-documentation/<tag name>/pkgdown/,
+  where <tag name> is the tag name for the new release.
 
 # CHANGES IN BioCro VERSION 3.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,17 @@ Subsequent commits will then include a new "Unreleased" section in preparation
 for the next release.
 -->
 
+# CHANGES IN BioCro VERSION 3.0.1
+
+## MINOR CHANGES
+
+- This version pertains only to the GitHub documentation workflow.  It
+  changes the publication location to the
+  `biocro/BioCro-documentation` repository, and it changes the
+  triggers of the workflow so that automatic publication happens only
+  when a version tag matching the pattern 'v*.*' is pushed to the
+  repository.
+
 # CHANGES IN BioCro VERSION 3.0.0
 
 ## MAJOR CHANGES


### PR DESCRIPTION
Also: use `main` rather than `master` as the branch where pushes generate new documentation.

---

This is a stop-gap fix to get documentation up and running at the new location (under the `biocro` organization).

I'm temporarily using a landing page to ease the transition.

The old ebimodeling BioCro documentation page now points to that landing page.

If you don't like https://biocro.github.io/BioCro-documentation/ as the location, we can easily change it.  I considered just https://biocro.github.io/documentation/, thinking the extra "biocro" was redundant, but I wasn't sure if there would be other, separate documentation for other repositories under `biocro/`.  I used "BioCro-documentation" rather than "biocro-documentation" to distinguish between BioCro, the R package, and biocro, the organization; but maybe this is too fussy and will lead to unnecessary mistypings and 404 errors.  (The hostname portion of a URL is, in general, not case-sensitive, but the rest usually _is_ case sensitive.)