### PR TITLE
Update publication location and check out source with submodules.

### DIFF
--- a/.github/workflows/document_quantities.yml
+++ b/.github/workflows/document_quantities.yml
@@ -1,6 +1,8 @@
 name: Document quantities
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
     # [no inputs]
 

--- a/.github/workflows/document_quantities.yml
+++ b/.github/workflows/document_quantities.yml
@@ -4,12 +4,8 @@ on:
   workflow_dispatch:
     # [no inputs]
 
-  push:
-    branches:
-      - collect_quantity_info-revised
-
 env:
-  publish-to: "ebimodeling/biocro-documentation"
+  publish-to: "biocro/BioCro-documentation"
 
 jobs:
   build:
@@ -24,6 +20,7 @@ jobs:
     - name: 1. Check out master
       uses: actions/checkout@v3
       with:
+        submodules: true
         path: source
 
     - name: 2. Set up R


### PR DESCRIPTION
This updates the _Document quantities_ workflow to publish to the new location under `biocro/` and to automatically run when a new BioCro version is released.

For now, the quantities documentation isn't versioned.  Any updates will replace what was there before.