### PR TITLE
Changes to check workflow

### DIFF
--- a/.github/workflows/R-CMD-check-backend.yaml
+++ b/.github/workflows/R-CMD-check-backend.yaml
@@ -94,21 +94,21 @@ jobs:
           args <- paste0('c(\\"', paste(args_value, collapse = '\\", \\"'), '\\")')
 
           # store these in the environment
-          system(sprintf('echo "::set-output name=build_args::%s"', build_args))
-          system(sprintf('echo "::set-output name=args::%s"', args))
+          system(sprintf('echo "build_args=%s" >> $GITHUB_OUTPUT', build_args))
+          system(sprintf('echo "args=%s" >> $GITHUB_OUTPUT', args))
           #
           # NOTE (quoting hell!): The result of the sprintf
           # function--the string that will be passed to the system
           # function--will be something like (e.g.) this:
           #
-          #     'echo "::set-output name=args::c(\\"--no-manual\\", \\"--no-tests\\")"'
+          #     'echo "args=c(\\"--no-manual\\", \\"--no-tests\\")" >> $GITHUB_OUTPUT'
           #
           # Because in R strings a literal backslash must be written
           # as "\\", no matter which kind of quotes are used for
           # string delimiters, the command actually run by the shell
           # will then be
           #
-          #     echo "::set-output name=args::c(\"--no-manual\", \"--no-tests\")"
+          #     echo "args=c(\"--no-manual\", \"--no-tests\")" >> $GITHUB_OUTPUT
           #
           # and the value of the job output 'args' will then become
           #

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -101,14 +101,14 @@ jobs:
           #     ]
           # }.       
           filter:
-            '[?configName == `${{ github.event.inputs.platform-to-check }}`
+            '[?configName == `${{ inputs.platform-to-check }}`
                 || `${{ github.event_name }}` != ''workflow_dispatch''
                     && configName == ''R 3.6 on Ubuntu'']'
 
   # For debugging:
   display_matrix:
     name: "DEBUG: Display strategy matrix"
-    if: github.event.inputs.debug == 'true' || github.event_name != 'workflow_dispatch'
+    if: inputs.debug || github.event_name != 'workflow_dispatch'
     needs: matrix_prep
     runs-on: ubuntu-latest
     steps:
@@ -129,18 +129,18 @@ jobs:
       # to a bona fide boolean!
 
       check-manual:
-        "${{ github.event.inputs.check-manual == 'true'
+        "${{ inputs.check-manual
             || github.event_name != 'workflow_dispatch' }}"
       run-tests:
-        "${{ github.event.inputs.run-tests == 'true'
+        "${{ inputs.run-tests
             || github.event_name != 'workflow_dispatch' }}"
       check-examples:
-        "${{ github.event.inputs.check-examples == 'true'
+        "${{ inputs.check-examples
             || github.event_name != 'workflow_dispatch' }}"
       check-vignettes:
-        "${{ github.event.inputs.check-vignettes == 'true'
+        "${{ inputs.check-vignettes
             || github.event_name != 'workflow_dispatch' }}"
 
       debug:
-        "${{ github.event.inputs.debug == 'true' }}"
+        "${{ inputs.debug }}"
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -102,8 +102,7 @@ jobs:
           # }.       
           filter:
             '[?configName == `${{ inputs.platform-to-check }}`
-                || `${{ github.event_name }}` != ''workflow_dispatch''
-                    && configName == ''R 3.6 on Ubuntu'']'
+                || `${{ github.event_name }}` != ''workflow_dispatch'']'
 
   # For debugging:
   display_matrix:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -123,9 +123,12 @@ jobs:
       
       # Note: Non-manual dispatches automatically run the tests and
       # check the manual, examples, and vignettes!  Note that the
-      # github.event inputs will be strings (either 'true' or 'false')
-      # so we have to use the "== 'true'" clause to convert each value
-      # to a bona fide boolean!
+      # inputs.* values will have non-boolean values when the event is
+      # not 'workflow_dispatch'--namely, the non-truthy value '' (the
+      # empty string).  But the way the boolean operators (|| and &&)
+      # are used below ensure that the resulting expression always
+      # evaluates to a boolean value, as expected by the called
+      # workflow.
 
       check-manual:
         "${{ inputs.check-manual

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -141,5 +141,5 @@ jobs:
             || github.event_name != 'workflow_dispatch' }}"
 
       debug:
-        "${{ inputs.debug }}"
+        "${{ github.event_name == 'workflow_dispatch' && inputs.debug }}"
 


### PR DESCRIPTION
This PR makes one substantive change and two (for now) transparent ones:

The substantial change is that now, the checks are run for all specified platforms when the triggering event is a pull request.  Up until now, only R 3.6 on Ubuntu was tested by default to avoid running up against the workflow run limits imposed on private repositories; to test other platforms or R versions required manually dispatching the workflow.

The first transparent change was to replace the deprecated `set-output` command calls with the use of environment files, the recommended equivalent.  See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for details.  (The `set-output` command was originally scheduled to be disabled on May 31, 2023, but that change has been delayed, and so this workflow has continued to work up until now.  Presumably, it would eventually start to fail without this change in place.)

The second transparent change is simply a simplification of the syntax, replacing usages of the `github.event.inputs` context with the `inputs` context.  Besides shortening the code, it allows inputs declared as boolean to be treated as such instead of being treated as strings.  (See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#providing-inputs.)