### PR TITLE
Upgraded the versions of actions used by R-CMD-check workflow

### DIFF
--- a/.github/workflows/R-CMD-check-backend.yaml
+++ b/.github/workflows/R-CMD-check-backend.yaml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Check out repository
         if: ${{ !inputs.debug }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           submodules: true
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -57,13 +57,13 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           submodules: true
 
       - id: set-matrix
         name: Construct the strategy matrix
-        uses: JoshuaTheMiller/conditional-build-matrix@38b0036b90a7f5f1461f446948d156a714e4fa1e # release 0.0.1
+        uses: JoshuaTheMiller/conditional-build-matrix@v2.0.1
         with:
           inputFile: '.github/workflows/strategy_matrix.json'
 


### PR DESCRIPTION
We now use the latest (as of this writing) versions of the `JoshuaTheMiller/conditional-build-matrix` and `actions/checkout` actions.

This was motivated by the deprecation warning about the `set-output` command coming from the `JoshuaTheMiller/conditional-build-matrix` action—the same warning about _our_ code addressed by PR #50.