### PR TITLE
Try to fix a LaTeX error in the PDF documentation

### DIFF
--- a/man/module_creators.Rd
+++ b/man/module_creators.Rd
@@ -22,7 +22,8 @@
   \code{module_creators}.
 
   Although the description of \code{externalptr} objects is sparse, they are
-  briefly mentioned in the R documentation: \code{\link{externalptr-class}}.
+  briefly mentioned in the R documentation for basic classes, which can be
+  accessed by typing \code{?`externalptr-class`} from an R terminal.
 
   This function should not be used directly, and each module library package
   must have its own version. For these reasons, this function is not exported to


### PR DESCRIPTION
This PR is related to issue #51. One of the check warnings (for MacOS-latest using R version 3.6) is related to LaTeX errors when compiling the PDF version of the package documentation. Unfortunately, the actual errors themselves are not specified.

I tried running `R CMD Rd2pdf --no-clean biocro` on my machine as suggested here: https://stackoverflow.com/questions/10819959/diagnosing-r-package-build-warning-latex-errors-when-creating-pdf-version

Besides some minor warning messages in the `log` file, I also found an error message in the `.ilg` file:

```
This is makeindex, version 2.16 [MiKTeX 23.1].
Scanning input file Rd2.idx....
!! Input index error (file = Rd2.idx, line = 99):
   -- Extra `@' at position 37 of first argument.
done (231 entries accepted, 1 rejected).
Sorting entries.....done (1987 comparisons).
Generating output file Rd2.ind....
## Warning (input = Rd2.idx, line = 188; output = Rd2.ind, line = 181):
   -- Conflicting entries: multiple encaps for the same page under same key.
done (221 lines written, 1 warning).
Output written in Rd2.ind.
Transcript written in Rd2.ilg.
```

The index error about an extra `@` is in reference to this line (specifically the `\z@`):
```
\indexentry{externalptr\unhbox \voidb@x \kern \z@ \char `\-class@\texttt  {externalptr\unhbox \voidb@x \kern \z@ \char `\-class}|hyperindexformat{\textit}}{20}
```

I found that this error disappears if I remove `\code{\link{externalptr-class}}` from `module_creators.Rd`. This PR is a test to see if this has any impact on the workflow errors.