### PR TITLE
Address R CMD check issues

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,11 @@ Subsequent commits will then include a new "Unreleased" section in preparation
 for the next release.
 -->
 
+# CHANGES IN BioCro VERSION 3.0.3
+
+- Replaced instances of `sprintf` in boost files with `snprintf` to avoid
+  `R CMD check` warnings
+
 # CHANGES IN BioCro VERSION 3.0.2
 
 ## MINOR CHANGES

--- a/developer_documentation/adding_the_boost_libraries.md
+++ b/developer_documentation/adding_the_boost_libraries.md
@@ -51,10 +51,16 @@ operating systems without it. Hence the need for
 
 4. Update the path to the Boost license in the package `LICENSE` file.
 
-5. Run `R CMD check` and truncate any boost file paths that are flagged as
-   exceeding 100 characters. Be sure to update any associated `#include`
-   directives that reference these files; otherwise, compilation errors will
-   occur.
+5. Run `R CMD check` and address any new warnings or errors related to the boost
+   library. It is likely that the following issues will occur:
+
+   - Some file paths will exceed the 100 character limit. Truncate any such file
+     names, and be sure to update any associated `#include` directives that
+     reference these files; otherwise, compilation errors will occur.
+
+   - As of boost version 1.83, some of the boost libraries included with BioCro
+     call `sprintf`, which is not allowed by CRAN. Replace any such instances of
+     `sprintf` with `snprintf`.
 
 ### Notes for using bcp in Windows
 First, follow the instructions in the "Getting Started on Windows"

--- a/inc/boost/numeric/odeint/integrate/max_step_checker.hpp
+++ b/inc/boost/numeric/odeint/integrate/max_step_checker.hpp
@@ -69,7 +69,7 @@ public:
         if( m_steps++ >= m_max_steps )
         {
             char error_msg[200];
-            std::sprintf(error_msg, "Max number of iterations exceeded (%d).", m_max_steps);
+            std::snprintf(error_msg, sizeof(error_msg), "Max number of iterations exceeded (%d).", m_max_steps);
             BOOST_THROW_EXCEPTION( no_progress_error(error_msg) );
         }
     }
@@ -101,7 +101,7 @@ public:
         if( m_steps++ >= m_max_steps )
         {
             char error_msg[200];
-            std::sprintf(error_msg, "Max number of iterations exceeded (%d). A new step size was not found.", m_max_steps);
+            std::snprintf(error_msg, sizeof(error_msg), "Max number of iterations exceeded (%d). A new step size was not found.", m_max_steps);
             BOOST_THROW_EXCEPTION( step_adjustment_error(error_msg) );
         }
     }


### PR DESCRIPTION
This is a first attempt at addressing some of the issues identified and discussed in issue #51. Here, I've replaced `sprintf` by `snprintf` in `odeint`, as was done by the `BH` package. Obviously it's not a great solution, but I don't think it's feasible to wait until the `boost` library stops using `sprintf`. We have no idea how long that might take.

As we decide on solutions to the other issues, they can also be implemented on this branch. Then this hotfix will address all of them.