### PR TITLE
Address R CMD check issues

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,9 @@ be directly added to this file to describe the related changes.
 - This version adds a description of the BioCro git branching model to
   `contribution_guidelines.Rmd` and clarifies the process of updating `NEWS.md`.
 
+- Replaced instances of `sprintf` in boost files with `snprintf` to avoid
+  `R CMD check` warnings
+
 # CHANGES IN BioCro VERSION 3.0.2
 
 ## MINOR CHANGES

--- a/developer_documentation/adding_the_boost_libraries.md
+++ b/developer_documentation/adding_the_boost_libraries.md
@@ -51,10 +51,16 @@ operating systems without it. Hence the need for
 
 4. Update the path to the Boost license in the package `LICENSE` file.
 
-5. Run `R CMD check` and truncate any boost file paths that are flagged as
-   exceeding 100 characters. Be sure to update any associated `#include`
-   directives that reference these files; otherwise, compilation errors will
-   occur.
+5. Run `R CMD check` and address any new warnings or errors related to the boost
+   library. It is likely that the following issues will occur:
+
+   - Some file paths will exceed the 100 character limit. Truncate any such file
+     names, and be sure to update any associated `#include` directives that
+     reference these files; otherwise, compilation errors will occur.
+
+   - As of boost version 1.83, some of the boost libraries included with BioCro
+     call `sprintf`, which is not allowed by CRAN. Replace any such instances of
+     `sprintf` with `snprintf`.
 
 ### Notes for using bcp in Windows
 First, follow the instructions in the "Getting Started on Windows"

--- a/inc/boost/core/snprintf.hpp
+++ b/inc/boost/core/snprintf.hpp
@@ -1,0 +1,173 @@
+/*
+ *             Copyright Andrey Semashev 2022.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   snprintf.hpp
+ * \author Andrey Semashev
+ * \date   06.12.2022
+ *
+ * \brief  The header provides more portable definition of snprintf and vsnprintf,
+ *         as well as \c wchar_t counterparts.
+ */
+
+#ifndef BOOST_CORE_SNPRINTF_HPP_INCLUDED_
+#define BOOST_CORE_SNPRINTF_HPP_INCLUDED_
+
+#include <stdio.h>
+#include <wchar.h>
+#include <boost/config.hpp>
+
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#pragma once
+#endif
+
+#if defined(__MINGW32__)
+
+#include <cstddef>
+#include <cstdarg>
+#if !defined(__MINGW64_VERSION_MAJOR)
+#include <climits>
+#endif
+
+// MinGW32 and MinGW-w64 provide their own snprintf implementations that are compliant with the C standard.
+#define BOOST_CORE_DETAIL_MINGW_SNPRINTF
+
+#elif (defined(BOOST_MSSTL_VERSION) && BOOST_MSSTL_VERSION < 140)
+
+#include <cstddef>
+#include <cstdarg>
+#include <climits>
+
+// MSVC snprintfs are not conforming but they are good enough for typical use cases.
+#define BOOST_CORE_DETAIL_MSVC_LEGACY_SNPRINTF
+
+#endif
+
+namespace boost {
+
+namespace core {
+
+#if defined(BOOST_CORE_DETAIL_MINGW_SNPRINTF) || defined(BOOST_CORE_DETAIL_MSVC_LEGACY_SNPRINTF)
+
+#if defined(BOOST_CORE_DETAIL_MINGW_SNPRINTF)
+
+inline int vsnprintf(char* buf, std::size_t size, const char* format, std::va_list args)
+{
+    return __mingw_vsnprintf(buf, size, format, args);
+}
+
+inline int vswprintf(wchar_t* buf, std::size_t size, const wchar_t* format, std::va_list args)
+{
+#if defined(__MINGW64_VERSION_MAJOR)
+    int res = __mingw_vsnwprintf(buf, size, format, args);
+    // __mingw_vsnwprintf returns the number of characters to be printed, but (v)swprintf is expected to return -1 on truncation
+    if (static_cast< unsigned int >(res) >= size)
+        res = -1;
+    return res;
+#else
+    // Legacy MinGW32 does not provide __mingw_vsnwprintf, so use _vsnwprintf from MSVC CRT
+    if (BOOST_UNLIKELY(size == 0u || size > static_cast< std::size_t >(INT_MAX)))
+        return -1;
+
+    int res = _vsnwprintf(buf, size, format, args);
+    // (v)swprintf is expected to return -1 on truncation, so we only need to ensure the output is null-terminated
+    if (static_cast< unsigned int >(res) >= size)
+    {
+        buf[size - 1u] = L'\0';
+        res = -1;
+    }
+
+    return res;
+#endif
+}
+
+#elif defined(BOOST_CORE_DETAIL_MSVC_LEGACY_SNPRINTF)
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+// '_vsnprintf': This function or variable may be unsafe. Consider using _vsnprintf_s instead.
+#pragma warning(disable: 4996)
+#endif
+
+inline int vsnprintf(char* buf, std::size_t size, const char* format, std::va_list args)
+{
+    if (BOOST_UNLIKELY(size == 0u))
+        return 0;
+    if (BOOST_UNLIKELY(size > static_cast< std::size_t >(INT_MAX)))
+        return -1;
+
+    buf[size - 1u] = '\0';
+    int res = _vsnprintf(buf, size, format, args);
+    if (static_cast< unsigned int >(res) >= size)
+    {
+        // _vsnprintf returns -1 if the output was truncated and in case of other errors.
+        // Detect truncation by checking whether the output buffer was written over entirely.
+        if (buf[size - 1u] != '\0')
+        {
+            buf[size - 1u] = '\0';
+            res = static_cast< int >(size);
+        }
+    }
+
+    return res;
+}
+
+inline int vswprintf(wchar_t* buf, std::size_t size, const wchar_t* format, std::va_list args)
+{
+    if (BOOST_UNLIKELY(size == 0u || size > static_cast< std::size_t >(INT_MAX)))
+        return -1;
+
+    int res = _vsnwprintf(buf, size, format, args);
+    // (v)swprintf is expected to return -1 on truncation, so we only need to ensure the output is null-terminated
+    if (static_cast< unsigned int >(res) >= size)
+    {
+        buf[size - 1u] = L'\0';
+        res = -1;
+    }
+
+    return res;
+}
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+#endif
+
+inline int snprintf(char* buf, std::size_t size, const char* format, ...)
+{
+    std::va_list args;
+    va_start(args, format);
+    int res = vsnprintf(buf, size, format, args);
+    va_end(args);
+    return res;
+}
+
+inline int swprintf(wchar_t* buf, std::size_t size, const wchar_t* format, ...)
+{
+    std::va_list args;
+    va_start(args, format);
+    int res = vswprintf(buf, size, format, args);
+    va_end(args);
+    return res;
+}
+
+#else // defined(BOOST_CORE_DETAIL_MINGW_SNPRINTF) || defined(BOOST_CORE_DETAIL_MSVC_LEGACY_SNPRINTF)
+
+// Standard-conforming compilers already have the correct snprintfs
+using ::snprintf;
+using ::vsnprintf;
+
+using ::swprintf;
+using ::vswprintf;
+
+#endif // defined(BOOST_CORE_DETAIL_MINGW_SNPRINTF) || defined(BOOST_CORE_DETAIL_MSVC_LEGACY_SNPRINTF)
+
+} // namespace core
+
+} // namespace boost
+
+#endif // BOOST_CORE_SNPRINTF_HPP_INCLUDED_

--- a/inc/boost/lexical_cast/detail/converter_lexical_streams.hpp
+++ b/inc/boost/lexical_cast/detail/converter_lexical_streams.hpp
@@ -37,6 +37,7 @@
 #include <boost/type_traits/is_pointer.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/detail/workaround.hpp>
+#include <boost/core/snprintf.hpp>
 
 
 #ifndef BOOST_NO_STD_LOCALE
@@ -154,7 +155,7 @@ namespace boost {
             CharT   buffer[CharacterBufferSize];
 
             // After the `operator <<`  finishes, `[start, finish)` is
-            // the range to output by `operator >>` 
+            // the range to output by `operator >>`
             const CharT*  start;
             const CharT*  finish;
 
@@ -165,7 +166,7 @@ namespace boost {
               , start(buffer)
               , finish(buffer + CharacterBufferSize)
             {}
-    
+
             const CharT* cbegin() const BOOST_NOEXCEPT {
                 return start;
             }
@@ -279,11 +280,7 @@ namespace boost {
                 using namespace std;
                 const double val_as_double = val;
                 finish = start +
-#if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(__SGI_STL_PORT) && !defined(_STLPORT_VERSION)
-                    sprintf_s(begin, CharacterBufferSize,
-#else
-                    sprintf(begin, 
-#endif
+                    boost::core::snprintf(begin, CharacterBufferSize,
                     "%.*g", static_cast<int>(boost::detail::lcast_get_precision<float>()), val_as_double);
                 return finish > start;
             }
@@ -291,11 +288,7 @@ namespace boost {
             bool shl_real_type(double val, char* begin) {
                 using namespace std;
                 finish = start +
-#if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(__SGI_STL_PORT) && !defined(_STLPORT_VERSION)
-                    sprintf_s(begin, CharacterBufferSize,
-#else
-                    sprintf(begin, 
-#endif
+                    boost::core::snprintf(begin, CharacterBufferSize,
                     "%.*g", static_cast<int>(boost::detail::lcast_get_precision<double>()), val);
                 return finish > start;
             }
@@ -304,11 +297,7 @@ namespace boost {
             bool shl_real_type(long double val, char* begin) {
                 using namespace std;
                 finish = start +
-#if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(__SGI_STL_PORT) && !defined(_STLPORT_VERSION)
-                    sprintf_s(begin, CharacterBufferSize,
-#else
-                    sprintf(begin, 
-#endif
+                    boost::core::snprintf(begin, CharacterBufferSize,
                     "%.*Lg", static_cast<int>(boost::detail::lcast_get_precision<long double>()), val );
                 return finish > start;
             }
@@ -375,15 +364,15 @@ namespace boost {
             }
 
             template <class C>
-            BOOST_DEDUCED_TYPENAME boost::disable_if<boost::is_const<C>, bool>::type 
+            BOOST_DEDUCED_TYPENAME boost::disable_if<boost::is_const<C>, bool>::type
             operator<<(const iterator_range<C*>& rng) BOOST_NOEXCEPT {
                 return (*this) << iterator_range<const C*>(rng.begin(), rng.end());
             }
-            
+
             bool operator<<(const iterator_range<const CharT*>& rng) BOOST_NOEXCEPT {
                 start = rng.begin();
                 finish = rng.end();
-                return true; 
+                return true;
             }
 
             bool operator<<(const iterator_range<const signed char*>& rng) BOOST_NOEXCEPT {
@@ -454,43 +443,43 @@ namespace boost {
                 return shl_real(static_cast<double>(val));
 #endif
             }
-            
+
             // Adding constness to characters. Constness does not change layout
             template <class C, std::size_t N>
             BOOST_DEDUCED_TYPENAME boost::disable_if<boost::is_const<C>, bool>::type
-            operator<<(boost::array<C, N> const& input) BOOST_NOEXCEPT { 
+            operator<<(boost::array<C, N> const& input) BOOST_NOEXCEPT {
                 BOOST_STATIC_ASSERT_MSG(
                     (sizeof(boost::array<const C, N>) == sizeof(boost::array<C, N>)),
                     "boost::array<C, N> and boost::array<const C, N> must have exactly the same layout."
                 );
-                return ((*this) << reinterpret_cast<boost::array<const C, N> const& >(input)); 
+                return ((*this) << reinterpret_cast<boost::array<const C, N> const& >(input));
             }
 
             template <std::size_t N>
-            bool operator<<(boost::array<const CharT, N> const& input) BOOST_NOEXCEPT { 
+            bool operator<<(boost::array<const CharT, N> const& input) BOOST_NOEXCEPT {
                 return shl_char_array_limited(input.data(), N);
             }
 
             template <std::size_t N>
-            bool operator<<(boost::array<const unsigned char, N> const& input) BOOST_NOEXCEPT { 
-                return ((*this) << reinterpret_cast<boost::array<const char, N> const& >(input)); 
+            bool operator<<(boost::array<const unsigned char, N> const& input) BOOST_NOEXCEPT {
+                return ((*this) << reinterpret_cast<boost::array<const char, N> const& >(input));
             }
 
             template <std::size_t N>
-            bool operator<<(boost::array<const signed char, N> const& input) BOOST_NOEXCEPT { 
-                return ((*this) << reinterpret_cast<boost::array<const char, N> const& >(input)); 
+            bool operator<<(boost::array<const signed char, N> const& input) BOOST_NOEXCEPT {
+                return ((*this) << reinterpret_cast<boost::array<const char, N> const& >(input));
             }
- 
+
 #ifndef BOOST_NO_CXX11_HDR_ARRAY
             // Making a Boost.Array from std::array
             template <class C, std::size_t N>
-            bool operator<<(std::array<C, N> const& input) BOOST_NOEXCEPT { 
+            bool operator<<(std::array<C, N> const& input) BOOST_NOEXCEPT {
                 BOOST_STATIC_ASSERT_MSG(
                     (sizeof(std::array<C, N>) == sizeof(boost::array<C, N>)),
                     "std::array and boost::array must have exactly the same layout. "
                     "Bug in implementation of std::array or boost::array."
                 );
-                return ((*this) << reinterpret_cast<boost::array<C, N> const& >(input)); 
+                return ((*this) << reinterpret_cast<boost::array<C, N> const& >(input));
             }
 #endif
             template <class InStreamable>
@@ -500,7 +489,7 @@ namespace boost {
 
         template <class CharT, class Traits>
         class lexical_ostream_limited_src: boost::noncopyable {
-            //`[start, finish)` is the range to output by `operator >>` 
+            //`[start, finish)` is the range to output by `operator >>`
             const CharT*        start;
             const CharT* const  finish;
 
@@ -580,7 +569,7 @@ namespace boost {
 #else
                 typedef BOOST_DEDUCED_TYPENAME out_stream_helper_trait<CharT, Traits>::buffer_t buffer_t;
                 buffer_t buf;
-                // Usually `istream` and `basic_istream` do not modify 
+                // Usually `istream` and `basic_istream` do not modify
                 // content of buffer; `buffer_t` assures that this is true
                 buf.setbuf(const_cast<CharT*>(start), static_cast<typename buffer_t::streamsize>(finish - start));
 #if defined(BOOST_NO_STD_LOCALE)
@@ -597,7 +586,7 @@ namespace boost {
                 stream.unsetf(std::ios::skipws);
                 lcast_set_precision(stream, static_cast<InputStreamable*>(0));
 
-                return (stream >> output) 
+                return (stream >> output)
                     && (stream.get() == Traits::eof());
 
 #ifndef BOOST_NO_EXCEPTIONS
@@ -625,7 +614,7 @@ namespace boost {
             bool shr_std_array(ArrayT& output) BOOST_NOEXCEPT {
                 using namespace std;
                 const std::size_t size = static_cast<std::size_t>(finish - start);
-                if (size > N - 1) { // `-1` because we need to store \0 at the end 
+                if (size > N - 1) { // `-1` because we need to store \0 at the end
                     return false;
                 }
 
@@ -668,33 +657,33 @@ namespace boost {
             bool operator>>(char32_t& output)                   { return shr_xchar(output); }
 #endif
             template<class Alloc>
-            bool operator>>(std::basic_string<CharT,Traits,Alloc>& str) { 
-                str.assign(start, finish); return true; 
+            bool operator>>(std::basic_string<CharT,Traits,Alloc>& str) {
+                str.assign(start, finish); return true;
             }
 
             template<class Alloc>
-            bool operator>>(boost::container::basic_string<CharT,Traits,Alloc>& str) { 
-                str.assign(start, finish); return true; 
+            bool operator>>(boost::container::basic_string<CharT,Traits,Alloc>& str) {
+                str.assign(start, finish); return true;
             }
 
             template <std::size_t N>
-            bool operator>>(boost::array<CharT, N>& output) BOOST_NOEXCEPT { 
-                return shr_std_array<N>(output); 
+            bool operator>>(boost::array<CharT, N>& output) BOOST_NOEXCEPT {
+                return shr_std_array<N>(output);
             }
 
             template <std::size_t N>
-            bool operator>>(boost::array<unsigned char, N>& output) BOOST_NOEXCEPT { 
-                return ((*this) >> reinterpret_cast<boost::array<char, N>& >(output)); 
+            bool operator>>(boost::array<unsigned char, N>& output) BOOST_NOEXCEPT {
+                return ((*this) >> reinterpret_cast<boost::array<char, N>& >(output));
             }
 
             template <std::size_t N>
-            bool operator>>(boost::array<signed char, N>& output) BOOST_NOEXCEPT { 
-                return ((*this) >> reinterpret_cast<boost::array<char, N>& >(output)); 
+            bool operator>>(boost::array<signed char, N>& output) BOOST_NOEXCEPT {
+                return ((*this) >> reinterpret_cast<boost::array<char, N>& >(output));
             }
- 
+
 #ifndef BOOST_NO_CXX11_HDR_ARRAY
             template <class C, std::size_t N>
-            bool operator>>(std::array<C, N>& output) BOOST_NOEXCEPT { 
+            bool operator>>(std::array<C, N>& output) BOOST_NOEXCEPT {
                 BOOST_STATIC_ASSERT_MSG(
                     (sizeof(std::array<C, N>) == sizeof(boost::array<C, N>)),
                     "std::array<C, N> and boost::array<C, N> must have exactly the same layout."
@@ -773,8 +762,8 @@ namespace boost {
             // Generic istream-based algorithm.
             // lcast_streambuf_for_target<InputStreamable>::value is true.
             template <typename InputStreamable>
-            bool operator>>(InputStreamable& output) { 
-                return shr_using_base_class(output); 
+            bool operator>>(InputStreamable& output) {
+                return shr_using_base_class(output);
             }
         };
     }

--- a/inc/boost/numeric/odeint/integrate/max_step_checker.hpp
+++ b/inc/boost/numeric/odeint/integrate/max_step_checker.hpp
@@ -69,7 +69,7 @@ public:
         if( m_steps++ >= m_max_steps )
         {
             char error_msg[200];
-            std::sprintf(error_msg, "Max number of iterations exceeded (%d).", m_max_steps);
+            std::snprintf(error_msg, sizeof(error_msg), "Max number of iterations exceeded (%d).", m_max_steps);
             BOOST_THROW_EXCEPTION( no_progress_error(error_msg) );
         }
     }
@@ -101,7 +101,7 @@ public:
         if( m_steps++ >= m_max_steps )
         {
             char error_msg[200];
-            std::sprintf(error_msg, "Max number of iterations exceeded (%d). A new step size was not found.", m_max_steps);
+            std::snprintf(error_msg, sizeof(error_msg), "Max number of iterations exceeded (%d). A new step size was not found.", m_max_steps);
             BOOST_THROW_EXCEPTION( step_adjustment_error(error_msg) );
         }
     }


### PR DESCRIPTION
This is a first attempt at addressing some of the issues identified and discussed in issue #51. Here, I've replaced `sprintf` by `snprintf` in `odeint`, as was done by the `BH` package. Obviously it's not a great solution, but I don't think it's feasible to wait until the `boost` library stops using `sprintf`. We have no idea how long that might take.

As we decide on solutions to the other issues, they can also be implemented on this branch.

Update: I originally made these changes on a hotfix branch because these changes are urgent. But, when `main` is the target, the checks do not run on all operating systems and R versions, because those modifications were introduced as a feature and only exist on `develop`.