### PR TITLE
Make not checking the manual the default.

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,7 +12,7 @@ on:
       check-manual:
         description: 'Check the manual'
         type: boolean
-        default: true
+        default: false
       check-vignettes:
         description: 'Check the vignettes'
         type: boolean

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -122,17 +122,17 @@ jobs:
       strategy-matrix: ${{ needs.matrix_prep.outputs.matrix }}
       
       # Note: Non-manual dispatches automatically run the tests and
-      # check the manual, examples, and vignettes!  Note that the
-      # inputs.* values will have non-boolean values when the event is
-      # not 'workflow_dispatch'--namely, the non-truthy value '' (the
-      # empty string).  But the way the boolean operators (|| and &&)
-      # are used below ensure that the resulting expression always
-      # evaluates to a boolean value, as expected by the called
-      # workflow.
+      # check the examples and the vignettes, but do not check the
+      # manual.  Note that the inputs.* values will have non-boolean
+      # values when the event is not 'workflow_dispatch'--namely, the
+      # non-truthy value '' (the empty string).  But the way the
+      # boolean operators (|| and &&) are used below ensure that the
+      # resulting expression always evaluates to a boolean value, as
+      # expected by the called workflow.
 
       check-manual:
-        "${{ inputs.check-manual
-            || github.event_name != 'workflow_dispatch' }}"
+        "${{ github.event_name == 'workflow_dispatch'
+            && inputs.check-manual }}"
       run-tests:
         "${{ inputs.run-tests
             || github.event_name != 'workflow_dispatch' }}"

--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,9 @@ be directly added to this file to describe the related changes.
 - Replaced instances of `sprintf` in boost files with `snprintf` to avoid
   `R CMD check` warnings
 
+- Modified the R-CMD-check workflow so that the manual is not checked
+  when the workflow runs automatically.
+
 # CHANGES IN BioCro VERSION 3.0.2
 
 ## MINOR CHANGES

--- a/NEWS.md
+++ b/NEWS.md
@@ -41,7 +41,8 @@ be directly added to this file to describe the related changes.
   `R CMD check` warnings
 
 - Modified the R-CMD-check workflow so that the manual is not checked
-  when the workflow runs automatically.
+  when the workflow runs automatically.  This has also been made the
+  default when the workflow is run manually.
 
 # CHANGES IN BioCro VERSION 3.0.2
 


### PR DESCRIPTION
`--no-manual` is only the default when the check workflow is run automatically.  Checking the manual is the default when the check workflow is run manually, but the user can always uncheck the "Check the manual" checkbox to skip checking of the manual.