### PR TITLE
Add and change workflow options

### DIFF
--- a/.github/workflows/R-CMD-check-backend.yaml
+++ b/.github/workflows/R-CMD-check-backend.yaml
@@ -54,7 +54,7 @@ jobs:
 
   # For debugging
   echo-inputs:
-    name: "DEBUG: Echo inputs"
+    name: "DEBUG: Echo inputs and environment variables"
     runs-on: ubuntu-latest
     steps:
       - name: Show inputs
@@ -66,6 +66,11 @@ jobs:
           echo 'check-vignettes: ${{ inputs.check-vignettes }}'
           echo 'as-cran: ${{ inputs.as-cran }}'
           echo 'error-on: ${{ inputs.error-on }}'
+      - name: Print environment variables
+        run: |
+          echo "github.event_name: ${{ github.event_name }}"
+          echo "NEED_TEX: ${{ env.NEED_TEX }}"
+          echo "NEED_TEX_EXTRAS: ${{ env.NEED_TEX_EXTRAS }}"
 
   compute-check-args:
     name: 'Compute "R CMD check" args'
@@ -152,18 +157,18 @@ jobs:
           echo 'R version: ${{ matrix.r }}'
           echo 'HTTP user agent: ${{ matrix.http-user-agent }}'
 
+      # For debugging
+      - name: "DEBUG: Show check-r-package arg values"
+        run: |
+          echo 'args = ${{ needs.compute-check-args.outputs.args }}'
+          echo 'build_args = ${{ needs.compute-check-args.outputs.build_args }}'
+          echo 'error-on = ${{ needs.compute-check-args.outputs.error_on }}'
+
       - name: Check out repository
         if: ${{ !inputs.dry-run }}
         uses: actions/checkout@v3
         with:
           submodules: true
-
-      # For debugging
-      - name: "DEBUG: Print environment variables"
-        run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "NEED_TEX: ${{ env.NEED_TEX }}"
-          echo "NEED_TEX_EXTRAS: ${{ env.NEED_TEX_EXTRAS }}"
 
       - name: Install Pandoc
         if: ${{ !inputs.dry-run }}
@@ -220,13 +225,6 @@ jobs:
           })
 
         shell: Rscript {0}
-
-      # For debugging
-      - name: "DEBUG: Show check-r-package arg values"
-        run: |
-          echo 'args = ${{ needs.compute-check-args.outputs.args }}'
-          echo 'build_args = ${{ needs.compute-check-args.outputs.build_args }}'
-          echo 'error-on = ${{ needs.compute-check-args.outputs.error_on }}'
 
       - name: Check package
         if: ${{ !inputs.dry-run }}

--- a/.github/workflows/R-CMD-check-backend.yaml
+++ b/.github/workflows/R-CMD-check-backend.yaml
@@ -37,6 +37,10 @@ on:
         type: boolean
       debug:
         type: boolean
+      as-cran:
+        type: boolean
+      error-on:
+        type: string
 
 env:
 
@@ -61,6 +65,8 @@ jobs:
           echo 'run-tests: ${{ inputs.run-tests }}'
           echo 'check-examples: ${{ inputs.check-examples }}'
           echo 'check-vignettes: ${{ inputs.check-vignettes }}'
+          echo 'as-cran: ${{ inputs.as-cran }}'
+          echo 'error-on: ${{ inputs.error-on }}'
 
   compute-check-args:
     name: 'Compute "R CMD check" args'
@@ -68,12 +74,14 @@ jobs:
     outputs:
       build_args: ${{ steps.compute-args.outputs.build_args }}
       args: ${{ steps.compute-args.outputs.args }}
+      error_on: ${{ steps.compute-args.outputs.error_on }}
     steps:
       - id: compute-args
         name: Compute args
         run: |
           build_args_value <- c()
-          args_value <- c('--as-cran')
+          args_value <- c()
+
           if ('${{ inputs.check-manual }}' == 'false') {
             build_args_value <- append(build_args_value, '--no-manual')
             args_value <- append(args_value, '--no-manual')
@@ -88,14 +96,19 @@ jobs:
           if ('${{ inputs.check-examples }}' == 'false') {
             args_value <- append(args_value, '--no-examples')
           }
+          if ('${{ inputs.as-cran }}' == 'true') {
+            args_value <- append(args_value, '--as-cran')
+          }
 
           # serialize these vectors as strings (see note below):
           build_args <- paste0('c(\\"', paste(build_args_value, collapse = '\\", \\"'), '\\")')
           args <- paste0('c(\\"', paste(args_value, collapse = '\\", \\"'), '\\")')
+          error_on <- '\\"${{ inputs.error-on }}\\"'
 
           # store these in the environment
           system(sprintf('echo "build_args=%s" >> $GITHUB_OUTPUT', build_args))
           system(sprintf('echo "args=%s" >> $GITHUB_OUTPUT', args))
+          system(sprintf('echo "error_on=%s" >> $GITHUB_OUTPUT', error_on))
           #
           # NOTE (quoting hell!): The result of the sprintf
           # function--the string that will be passed to the system
@@ -217,6 +230,7 @@ jobs:
         run: |
           echo 'args = ${{ needs.compute-check-args.outputs.args }}'
           echo 'build_args = ${{ needs.compute-check-args.outputs.build_args }}'
+          echo 'error-on = ${{ needs.compute-check-args.outputs.error_on }}'
 
       - name: Check package
         if: ${{ !inputs.debug }}
@@ -225,3 +239,4 @@ jobs:
           upload-snapshots: true
           args: ${{ needs.compute-check-args.outputs.args }}
           build_args: ${{ needs.compute-check-args.outputs.build_args }}
+          error-on: ${{ needs.compute-check-args.outputs.error_on }}

--- a/.github/workflows/R-CMD-check-backend.yaml
+++ b/.github/workflows/R-CMD-check-backend.yaml
@@ -35,7 +35,7 @@ on:
         type: boolean
       check-vignettes:
         type: boolean
-      debug:
+      dry-run:
         type: boolean
       as-cran:
         type: boolean
@@ -55,7 +55,6 @@ jobs:
   # For debugging
   echo-inputs:
     name: "DEBUG: Echo inputs"
-    if: inputs.debug
     runs-on: ubuntu-latest
     steps:
       - name: Show inputs
@@ -148,32 +147,30 @@ jobs:
 
       # For debugging
       - name: "DEBUG: Show current values from the strategy matrix"
-        if: inputs.debug
         run: |
           echo 'os: ${{ matrix.os }}'
           echo 'R version: ${{ matrix.r }}'
           echo 'HTTP user agent: ${{ matrix.http-user-agent }}'
 
       - name: Check out repository
-        if: ${{ !inputs.debug }}
+        if: ${{ !inputs.dry-run }}
         uses: actions/checkout@v3
         with:
           submodules: true
 
       # For debugging
       - name: "DEBUG: Print environment variables"
-        if: inputs.debug
         run: |
           echo "github.event_name: ${{ github.event_name }}"
           echo "NEED_TEX: ${{ env.NEED_TEX }}"
           echo "NEED_TEX_EXTRAS: ${{ env.NEED_TEX_EXTRAS }}"
 
       - name: Install Pandoc
-        if: ${{ !inputs.debug }}
+        if: ${{ !inputs.dry-run }}
         uses: r-lib/actions/setup-pandoc@v2
 
       - name: Set up R
-        if: ${{ !inputs.debug }}
+        if: ${{ !inputs.dry-run }}
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.r }}
@@ -181,18 +178,18 @@ jobs:
           use-public-rspm: true
 
       - name: Set up R dependencies
-        if: ${{ !inputs.debug }}
+        if: ${{ !inputs.dry-run }}
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck
           needs: check
 
       - name: Install TinyTex
-        if: ${{ env.NEED_TEX == 'true' && !inputs.debug }}
+        if: ${{ env.NEED_TEX == 'true' && !inputs.dry-run }}
         uses: r-lib/actions/setup-tinytex@v2
 
       - name: Install extra LaTeX packages
-        if: ${{ env.NEED_TEX_EXTRAS == 'true' && !inputs.debug }}
+        if: ${{ env.NEED_TEX_EXTRAS == 'true' && !inputs.dry-run }}
         run: |
 
           # Install the tinytex R package to run tinytex::pdflatex.
@@ -226,14 +223,13 @@ jobs:
 
       # For debugging
       - name: "DEBUG: Show check-r-package arg values"
-        if: inputs.debug
         run: |
           echo 'args = ${{ needs.compute-check-args.outputs.args }}'
           echo 'build_args = ${{ needs.compute-check-args.outputs.build_args }}'
           echo 'error-on = ${{ needs.compute-check-args.outputs.error_on }}'
 
       - name: Check package
-        if: ${{ !inputs.debug }}
+        if: ${{ !inputs.dry-run }}
         uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,11 +39,11 @@ on:
           - info
         default: warning
 
-      # Should we show debug output?  (This will also skip doing the
-      # actual package check and the lengthy steps involved in doing
-      # such a check.)
-      debug:
-        description: 'Show output for debugging'
+      # This will show some configuration variables but will skip
+      # doing the actual package check and the lengthy steps involved
+      # in doing such a check.
+      dry-run:
+        description: Don't actually run the check; show output for debugging
         type: boolean
         default: false
 
@@ -120,7 +120,6 @@ jobs:
   # For debugging:
   display_matrix:
     name: "DEBUG: Display strategy matrix"
-    if: inputs.debug || github.event_name != 'workflow_dispatch'
     needs: matrix_prep
     runs-on: ubuntu-latest
     steps:
@@ -162,6 +161,6 @@ jobs:
         "${{ inputs.error-on
             || github.event_name != 'workflow_dispatch' && 'warning' }}"
 
-      debug:
-        "${{ github.event_name == 'workflow_dispatch' && inputs.debug }}"
+      dry-run:
+        "${{ github.event_name == 'workflow_dispatch' && inputs.dry-run }}"
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,6 +25,19 @@ on:
         description: 'Check the examples'
         type: boolean
         default: true
+      as-cran:
+        description: 'Use the --as-cran option when checking'
+        type: boolean
+        default: true
+      error-on:
+        description: 'When to trigger an error'
+        type: choice
+        options:
+          - never
+          - error
+          - warning
+          - info
+        default: warning
 
       # Should we show debug output?  (This will also skip doing the
       # actual package check and the lengthy steps involved in doing
@@ -142,6 +155,12 @@ jobs:
       check-vignettes:
         "${{ inputs.check-vignettes
             || github.event_name != 'workflow_dispatch' }}"
+      as-cran:
+        "${{ inputs.as-cran
+            || github.event_name != 'workflow_dispatch' }}"
+      error-on:
+        "${{ inputs.error-on
+            || github.event_name != 'workflow_dispatch' && 'warning' }}"
 
       debug:
         "${{ github.event_name == 'workflow_dispatch' && inputs.debug }}"

--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,27 @@ be directly added to this file to describe the related changes.
 - This version adds a description of the BioCro git branching model to
   `contribution_guidelines.Rmd` and clarifies the process of updating `NEWS.md`.
 
+- It also changes the R-CMD-check workflow in the following ways:
+
+  - When the check workflow is run manually, there are two new input
+    options:
+
+    - The user can now choose whether or not to run R CMD check with
+      the --as-cran option.  Formerly, this was always used.
+
+    - The user can choose whether and when to throw an error on R CMD
+      check failures.  Formerly, an error was thrown whenever the R
+      CMD check failure was either "warning" or "error".
+
+  - Output that was formerly shown only on manual runs when the
+    "debug" checkbox was selected is now always shown.  The "debug"
+    option has been changed to "dry-run", which results in the debug
+    output being shown but the actually check, and those set-up steps
+    needed only to carry out the check, are skipped.
+
+  - The debug output steps are grouped together when possible, and the
+    output is shown earlier on in the workflow.
+
 # CHANGES IN BioCro VERSION 3.0.2
 
 ## MINOR CHANGES


### PR DESCRIPTION
Allow choosing not to use `--as-cran` and to not treat warnings as errors when workflow is run manually; always show debug information.

See the NEWS.md file for details.