### PR TITLE
Upgraded to using the latest versions of all GitHub and 3rd-party actions

### DIFF
--- a/.github/workflows/R-CMD-check-backend.yaml
+++ b/.github/workflows/R-CMD-check-backend.yaml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Check out repository
         if: ${{ !inputs.debug }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           submodules: true
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -57,13 +57,13 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           submodules: true
 
       - id: set-matrix
         name: Construct the strategy matrix
-        uses: JoshuaTheMiller/conditional-build-matrix@38b0036b90a7f5f1461f446948d156a714e4fa1e # release 0.0.1
+        uses: JoshuaTheMiller/conditional-build-matrix@81b51eb8d89e07b86404934b5fecde1cea1163a5 # release 2.0.1
         with:
           inputFile: '.github/workflows/strategy_matrix.json'
 

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -65,7 +65,7 @@ jobs:
         echo "VERSION=${GITHUB_REF_NAME////_}" >> $GITHUB_ENV
 
     - name: 1. Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.1
       with:
         submodules: true
 
@@ -114,7 +114,7 @@ jobs:
 
     - name: 7a. Check out the target "PUBLISH_TO" repository
       if: inputs.publish
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.1
       with:
         repository: ${{ env.PUBLISH_TO }}
         path: ${{ env.BIOCRO_DOCUMENTATION_ROOT }}
@@ -201,7 +201,7 @@ jobs:
 
     - name: 11. Upload artifact containing documentation
       if: always() # Even if some steps fail, at least try to make a documentation artifact.
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v3.1.3
       with:
         name: biocro-documentation
         path: biocro-docs-from-${{ env.VERSION }}.tgz

--- a/.github/workflows/document_quantities.yml
+++ b/.github/workflows/document_quantities.yml
@@ -20,7 +20,7 @@ jobs:
     # Checks out this repository under $GITHUB_WORKSPACE/source:
 
     - name: 1. Check out master
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.1
       with:
         submodules: true
         path: source
@@ -37,7 +37,7 @@ jobs:
       working-directory: source
 
     - name: 4. Cache R packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3.3.2
       with:
         path: ${{ env.R_LIBS_USER }}
         key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
@@ -87,7 +87,7 @@ jobs:
     # check in our changes later, in the Push step:
 
     - name: 10. Check out master of the "publish-to" repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.1.1
       with:
         repository: ${{ env.publish-to }}
         path: target

--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,9 @@ be directly added to this file to describe the related changes.
 - This version adds a description of the BioCro git branching model to
   `contribution_guidelines.Rmd` and clarifies the process of updating `NEWS.md`.
 
+- GitHub workflows and actions in the repository have been updated to
+  use the latest versions of all GitHub and 3rd-party actions.
+
 # CHANGES IN BioCro VERSION 3.0.2
 
 ## MINOR CHANGES


### PR DESCRIPTION
We now use the latest (as of this writing) versions of all actions.

This was motivated by the deprecation warnings coming from the `JoshuaTheMiller/conditional-build-matrix` action about the `set-output` command and the version of _node_ being used.  (A similar warning about `set-output` coming from _our_ code was addressed by PR https://github.com/biocro/biocro/pull/50.)