### PR TITLE
Address wformat warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -81,7 +81,7 @@ be directly added to this file to describe the related changes.
   precise layout of the online documentation.  Some other changes and
   clarifications to the documentation have been made as well.
 
-- Addressed some `Wformat-security` compiler warnings related to calling
+- Addressed some `format-security` compiler warnings related to calling
   `Rf_error` and `Rprintf` without a format specifier; a format specifier of
   `"%s"` should always be used when printing the value of a string variable.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -81,6 +81,10 @@ be directly added to this file to describe the related changes.
   precise layout of the online documentation.  Some other changes and
   clarifications to the documentation have been made as well.
 
+- Addressed some `Wformat-security` compiler warnings related to calling
+  `Rf_error` and `Rprintf` without a format specifier; a format specifier of
+  `"%s"` should always be used when printing the value of a string variable.
+
 # CHANGES IN BioCro VERSION 3.0.2
 
 ## MINOR CHANGES

--- a/src/R_dynamical_system.cpp
+++ b/src/R_dynamical_system.cpp
@@ -36,7 +36,7 @@ SEXP R_validate_dynamical_system_inputs(
         if (be_loud) {
             Rprintf("\nChecking the validity of the system inputs:\n");
 
-            Rprintf(msg.c_str());
+            Rprintf("%s", msg.c_str());
 
             if (valid) {
                 Rprintf("\nSystem inputs are valid\n");
@@ -47,7 +47,7 @@ SEXP R_validate_dynamical_system_inputs(
             Rprintf("\nPrinting additional information about the system inputs:\n");
 
             msg = analyze_system_inputs(s, ip, vp, direct_mcs, differential_mcs);
-            Rprintf(msg.c_str());
+            Rprintf("%s", msg.c_str());
 
             // Print a space to improve readability
             Rprintf("\n");
@@ -56,7 +56,7 @@ SEXP R_validate_dynamical_system_inputs(
         return r_logical_from_boolean(valid);
 
     } catch (std::exception const& e) {
-        Rf_error((string("Caught exception in R_validate_dynamical_system_inputs: ") + e.what()).c_str());
+        Rf_error("%s", (string("Caught exception in R_validate_dynamical_system_inputs: ") + e.what()).c_str());
     } catch (...) {
         Rf_error("Caught unhandled exception in R_validate_dynamical_system_inputs.");
     }

--- a/src/R_framework_version.cpp
+++ b/src/R_framework_version.cpp
@@ -19,7 +19,7 @@ SEXP R_framework_version()
         string_vector result = {version};
         return r_string_vector_from_vector(result);
     } catch (std::exception const& e) {
-        Rf_error((string("Caught exception in R_framework_version: ") + e.what()).c_str());
+        Rf_error("%s", (string("Caught exception in R_framework_version: ") + e.what()).c_str());
     } catch (...) {
         Rf_error("Caught unhandled exception in R_framework_version.");
     }

--- a/src/R_get_all_ode_solvers.cpp
+++ b/src/R_get_all_ode_solvers.cpp
@@ -16,7 +16,7 @@ SEXP R_get_all_ode_solvers()
         string_vector result = ode_solver_factory::get_ode_solvers();
         return r_string_vector_from_vector(result);
     } catch (std::exception const& e) {
-        Rf_error((string("Caught exception in R_get_all_ode_solvers: ") + e.what()).c_str());
+        Rf_error("%s", (string("Caught exception in R_get_all_ode_solvers: ") + e.what()).c_str());
     } catch (...) {
         Rf_error("Caught unhandled exception in R_get_all_ode_solvers.");
     }

--- a/src/R_module_library.cpp
+++ b/src/R_module_library.cpp
@@ -78,7 +78,7 @@ SEXP R_module_creators(SEXP module_names)
         return mw_ptr_vec;
 
     } catch (std::exception const& e) {
-        Rf_error((std::string("Caught exception in R_module_creators: ") + e.what()).c_str());
+        Rf_error("%s", (std::string("Caught exception in R_module_creators: ") + e.what()).c_str());
     } catch (...) {
         Rf_error("Caught unhandled exception in R_module_creators.");
     }
@@ -95,7 +95,7 @@ SEXP R_get_all_modules()
             module_factory<library>::get_all_modules();
         return r_string_vector_from_vector(result);
     } catch (std::exception const& e) {
-        Rf_error((string("Caught exception in R_get_all_modules: ") + e.what()).c_str());
+        Rf_error("%s", (string("Caught exception in R_get_all_modules: ") + e.what()).c_str());
     } catch (...) {
         Rf_error("Caught unhandled exception in R_get_all_modules.");
     }
@@ -112,7 +112,7 @@ SEXP R_get_all_quantities()
             module_factory<library>::get_all_quantities();
         return list_from_map(all_quantities);
     } catch (std::exception const& e) {
-        Rf_error((string("Caught exception in R_get_all_quantities: ") + e.what()).c_str());
+        Rf_error("%s", (string("Caught exception in R_get_all_quantities: ") + e.what()).c_str());
     } catch (...) {
         Rf_error("Caught unhandled exception in R_get_all_quantities.");
     }

--- a/src/R_modules.cpp
+++ b/src/R_modules.cpp
@@ -118,7 +118,7 @@ SEXP R_module_info(SEXP mw_ptr_vec, SEXP verbose)
             } else {
                 Rprintf("Error: could not create the module\n");
                 Rprintf("Additional details:\n");
-                Rprintf(creation_error_message.c_str());
+                Rprintf("%s", creation_error_message.c_str());
                 Rprintf("\n\n");
             }
         }
@@ -133,9 +133,9 @@ SEXP R_module_info(SEXP mw_ptr_vec, SEXP verbose)
             creation_error_message);
 
     } catch (quantity_access_error const& qae) {
-        Rf_error((string("Caught quantity access error in R_module_info: ") + qae.what()).c_str());
+        Rf_error("%s", (string("Caught quantity access error in R_module_info: ") + qae.what()).c_str());
     } catch (std::exception const& e) {
-        Rf_error((string("Caught exception in R_module_info: ") + e.what()).c_str());
+        Rf_error("%s", (string("Caught exception in R_module_info: ") + e.what()).c_str());
     } catch (...) {
         Rf_error("Caught unhandled exception in R_module_info.");
     }
@@ -186,9 +186,9 @@ SEXP R_evaluate_module(SEXP mw_ptr_vec, SEXP input_quantities)
         return list_from_map(module_output_map);
 
     } catch (quantity_access_error const& qae) {
-        Rf_error((string("Caught quantity access error in R_evaluate_module: ") + qae.what()).c_str());
+        Rf_error("%s", (string("Caught quantity access error in R_evaluate_module: ") + qae.what()).c_str());
     } catch (std::exception const& e) {
-        Rf_error((string("Caught exception in R_evaluate_module: ") + e.what()).c_str());
+        Rf_error("%s", (string("Caught exception in R_evaluate_module: ") + e.what()).c_str());
     } catch (...) {
         Rf_error("Caught unhandled exception in R_evaluate_module.");
     }

--- a/src/R_run_biocro.cpp
+++ b/src/R_run_biocro.cpp
@@ -50,12 +50,12 @@ SEXP R_run_biocro(
         state_vector_map result = gro.run_simulation();
 
         if (loquacious) {
-            Rprintf(gro.generate_report().c_str());
+            Rprintf("%s", gro.generate_report().c_str());
         }
 
         return list_from_map(result);
     } catch (std::exception const& e) {
-        Rf_error(string(string("Caught exception in R_run_biocro: ") + e.what()).c_str());
+        Rf_error("%s", string(string("Caught exception in R_run_biocro: ") + e.what()).c_str());
     } catch (...) {
         Rf_error("Caught unhandled exception in R_run_biocro.");
     }

--- a/src/R_system_derivatives.cpp
+++ b/src/R_system_derivatives.cpp
@@ -96,7 +96,7 @@ SEXP R_system_derivatives(
         return list_from_map(result);
 
     } catch (std::exception const& e) {
-        Rf_error((string("Caught exception in R_system_derivatives: ") + e.what()).c_str());
+        Rf_error("%s", (string("Caught exception in R_system_derivatives: ") + e.what()).c_str());
     } catch (...) {
         Rf_error("Caught unhandled exception in R_system_derivatives.");
     }


### PR DESCRIPTION
The `R CMD check` workflow started showing some warnings on ubuntu-20.04 using R version devel related to "format not a string literal and no format arguments [-Wformat-security]". I looked into it, and this is a pretty simple security fix: https://stackoverflow.com/questions/9707569/c-array-warning-format-not-a-string-literal

Update: both of the ubuntu checks now pass!