### PR TITLE
Commented out use of std::unary_function as base class for hash_base.

### DIFF
--- a/inc/boost/container_hash/hash.hpp
+++ b/inc/boost/container_hash/hash.hpp
@@ -118,17 +118,18 @@ namespace boost
 {
     namespace hash_detail
     {
-#if defined(_HAS_AUTO_PTR_ETC) && !_HAS_AUTO_PTR_ETC
+// Commenting out "else" code: don't rely on std::unary_function.
+// #if defined(_HAS_AUTO_PTR_ETC) && !_HAS_AUTO_PTR_ETC
         template <typename T>
         struct hash_base
         {
             typedef T argument_type;
             typedef std::size_t result_type;
         };
-#else
-        template <typename T>
-        struct hash_base : std::unary_function<T, std::size_t> {};
-#endif
+// #else
+//         template <typename T>
+//         struct hash_base : std::unary_function<T, std::size_t> {};
+// #endif
 
         struct enable_hash_value { typedef std::size_t type; };
 


### PR DESCRIPTION
With these changes, the checks pass on the [call-R-CMD-check / Check R package on windows-latest using R version release](https://github.com/biocro/biocro/actions/runs/7160194022/job/19494297283#logs) platform.