### PR TITLE
Make R 4.0.0 instead of R 3.6.0 the minimum supported R version

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -52,14 +52,14 @@ on:
         description: 'Platform to check'
         type: choice
         options:
-          - R 3.6 on Ubuntu
+          - R 4.0.0 on Ubuntu
           - R release version on Ubuntu
           - R devel version on Ubuntu
-          - R 3.6 on macOS
+          - R 4.0.0 on macOS
           - R release version on macOS
-          - R 3.6 on Windows
+          - R 4.0.0 on Windows
           - R release version on Windows
-        default: R 3.6 on Ubuntu
+        default: R 4.0.0 on Ubuntu
 
 jobs:
 
@@ -83,12 +83,12 @@ jobs:
           # This filter uses the JMESPath query language to modify the
           # strategy matrix (see https://jmespath.org/).  Note that if
           # the event is anything other than 'workflow_dispatch', the
-          # filter condition is true only when configName is 'R 3.6 on
-          # Ubuntu'.
+          # filter condition is true only when configName is 'R 4.0.0
+          # on Ubuntu'.
           #
           # For the public version of this repository, the "&&
-          # configName = 'R 3.6 on Ubuntu'" clause will be eliminated
-          # so that when the event is anything other than
+          # configName = 'R 4.0.0 on Ubuntu'" clause will be
+          # eliminated so that when the event is anything other than
           # 'workflow_dispatch', the filter condition is always true
           # and nothing gets filtered out: all the configurations will
           # be run.
@@ -98,18 +98,18 @@ jobs:
           # matrix.  Thus, if the result of the filter is
           # [
           #   {
-          #     "configName": "R 3.6 on Ubuntu",
+          #     "configName": "R 4.0.0 on Ubuntu",
           #     "os": "ubuntu-20.04",
-          #     "r": "3.6"
+          #     "r": "4.0.0"
           #   }
           # ],
           # the actual output will be
           # { "include":
           #     [
           #       {
-          #         "configName": "R 3.6 on Ubuntu",
+          #         "configName": "R 4.0.0 on Ubuntu",
           #         "os": "ubuntu-20.04",
-          #         "r": "3.6"
+          #         "r": "4.0.0"
           #       }
           #     ]
           # }.       

--- a/.github/workflows/strategy_matrix.json
+++ b/.github/workflows/strategy_matrix.json
@@ -1,18 +1,18 @@
 [
     {
-        "configName": "R 3.6 on Windows",
+        "configName": "R 4.0.0 on Windows",
         "os": "windows-latest",
-        "r": "3.6"
+        "r": "4.0.0"
     },
     {
-        "configName": "R 3.6 on macOS",
+        "configName": "R 4.0.0 on macOS",
         "os": "macOS-latest",
-        "r": "3.6"
+        "r": "4.0.0"
     },
     {
-        "configName": "R 3.6 on Ubuntu",
+        "configName": "R 4.0.0 on Ubuntu",
         "os": "ubuntu-20.04",
-        "r": "3.6"
+        "r": "4.0.0"
     },
     {
         "configName": "R release version on Ubuntu",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Authors@R: c(
     person("Boost Organization", role = "cph",
            comment = "Author of included Boost library")
     )
-Depends: R (>= 3.6.0)
+Depends: R (>= 4.0.0)
 Imports:
     stats
 Suggests:

--- a/NEWS.md
+++ b/NEWS.md
@@ -101,6 +101,9 @@ be directly added to this file to describe the related changes.
   `Rf_error` and `Rprintf` without a format specifier; a format specifier of
   `"%s"` should always be used when printing the value of a string variable.
 
+- The minimum supported R version is now 4.0.0.  The R-CMD-check
+  workflow has been updated accordingly.
+
 # CHANGES IN BioCro VERSION 3.0.2
 
 ## MINOR CHANGES


### PR DESCRIPTION
Make R 4.0.0 instead of R 3.6.0 the minimum supported R version, and update the test workflow accordingly.

The package check passes on all platform + R version configurations except Windows with the Release version of R (see https://github.com/biocro/biocro/actions/runs/7198925592/job/19609456910).  This is because of a failing harmonic oscillator test failure that @eloch216 alluded to earlier.

UPDATE: All checks passed in [Run #163](https://github.com/biocro/biocro/actions/runs/7199430426).  This really is an intermittent bug.