### PR TITLE
Eliminate the use of C99 designated initializers.

### DIFF
--- a/src/module_library/ball_berry_gs.cpp
+++ b/src/module_library/ball_berry_gs.cpp
@@ -143,8 +143,8 @@ stomata_outputs ball_berry_gs(
     double const gswmol = a * hs + bb_offset;  // mol / m^2 / s
 
     return stomata_outputs{
-        .cs = Cs * 1e6,      // micromol / mol
-        .hs = hs,            // dimensionless
-        .gsw = gswmol * 1e3  // mmol / m^2 / s
+        /* .cs = */ Cs * 1e6,      // micromol / mol
+        /* .hs = */ hs,            // dimensionless
+        /* .gsw = */ gswmol * 1e3  // mmol / m^2 / s
     };
 }

--- a/src/module_library/c3photo.cpp
+++ b/src/module_library/c3photo.cpp
@@ -169,15 +169,15 @@ photosynthesis_outputs c3photoC(
     }
 
     return photosynthesis_outputs{
-        .Assim = co2_assimilation_rate,       // micromol / m^2 / s
-        .Assim_conductance = an_conductance,  // micromol / m^2 / s
-        .Ci = Ci,                             // micromol / mol
-        .GrossAssim = FvCB_res.Vc,            // micromol / m^2 / s
-        .Gs = Gs * 1e3,                       // mmol / m^2 / s
-        .Cs = BB_res.cs,                      // micromol / m^2 / s
-        .RHs = BB_res.hs,                     // dimensionless from Pa / Pa
-        .Rp = FvCB_res.Vc * Gstar / Ci,       // micromol / m^2 / s
-        .iterations = iterCounter             // not a physical quantity
+        /* .Assim = */ co2_assimilation_rate,       // micromol / m^2 / s
+        /* .Assim_conductance = */ an_conductance,  // micromol / m^2 / s
+        /* .Ci = */ Ci,                             // micromol / mol
+        /* .GrossAssim = */ FvCB_res.Vc,            // micromol / m^2 / s
+        /* .Gs = */ Gs * 1e3,                       // mmol / m^2 / s
+        /* .Cs = */ BB_res.cs,                      // micromol / m^2 / s
+        /* .RHs = */ BB_res.hs,                     // dimensionless from Pa / Pa
+        /* .Rp = */ FvCB_res.Vc * Gstar / Ci,       // micromol / m^2 / s
+        /* .iterations = */ iterCounter             // not a physical quantity
     };
 }
 

--- a/src/module_library/c4photo.cpp
+++ b/src/module_library/c4photo.cpp
@@ -132,14 +132,14 @@ photosynthesis_outputs c4photoC(
     double Ci = InterCellularCO2 / atmospheric_pressure * 1e6;  // micromole / mol
 
     return photosynthesis_outputs{
-        .Assim = Assim,                       // micromol / m^2 /s
-        .Assim_conductance = an_conductance,  // micromol / m^2 / s
-        .Ci = Ci,                             // micromol / mol
-        .GrossAssim = Assim + RT,             // micromol / m^2 / s
-        .Gs = Gs,                             // mmol / m^2 / s
-        .Cs = BB_res.cs,                      // micromol / m^2 / s
-        .RHs = BB_res.hs,                     // dimensionless from Pa / Pa
-        .Rp = 0,                              // micromol / m^2 / s
-        .iterations = iterCounter             // not a physical quantity
+        /* .Assim = */ Assim,                       // micromol / m^2 /s
+        /* .Assim_conductance = */ an_conductance,  // micromol / m^2 / s
+        /* .Ci = */ Ci,                             // micromol / mol
+        /* .GrossAssim = */ Assim + RT,             // micromol / m^2 / s
+        /* .Gs = */ Gs,                             // mmol / m^2 / s
+        /* .Cs = */ BB_res.cs,                      // micromol / m^2 / s
+        /* .RHs = */ BB_res.hs,                     // dimensionless from Pa / Pa
+        /* .Rp = */ 0,                              // micromol / m^2 / s
+        /* .iterations = */ iterCounter             // not a physical quantity
     };
 }

--- a/src/module_library/collatz_photo.cpp
+++ b/src/module_library/collatz_photo.cpp
@@ -52,8 +52,8 @@ struct collatz_result collatz_photo(double Qp,  // micromole / m^2 / s. Incident
     double Assim = gross_assim - RT;  // micromole / m^2 / s.
 
     struct collatz_result result {
-            .assimilation = Assim,           // micromole / m^2 / s. Leaf area basis.
-            .gross_assimilation = Assim + RT  // micromole / m^2 / s. Leaf area basis.
+        /* .assimilation = */ Assim,           // micromole / m^2 / s. Leaf area basis.
+        /* .gross_assimilation = */ Assim + RT // micromole / m^2 / s. Leaf area basis.
     };
 
     return result;

--- a/src/module_library/lightME.cpp
+++ b/src/module_library/lightME.cpp
@@ -96,9 +96,9 @@ Light_model lightME(
     double const diffuse_fraction = 1.0 - direct_fraction;
 
     return Light_model{
-        .direct_transmittance = direct_transmittance,    // dimensionless
-        .diffuse_transmittance = diffuse_transmittance,  // dimensionless
-        .direct_fraction = direct_fraction,              // dimensionless
-        .diffuse_fraction = diffuse_fraction             // dimensionless
+        /* .direct_transmittance = */ direct_transmittance,    // dimensionless
+        /* .diffuse_transmittance = */ diffuse_transmittance,  // dimensionless
+        /* .direct_fraction = */ direct_fraction,              // dimensionless
+        /* .diffuse_fraction = */ diffuse_fraction             // dimensionless
     };
 }

--- a/src/module_library/rue_leaf_photosynthesis.cpp
+++ b/src/module_library/rue_leaf_photosynthesis.cpp
@@ -72,14 +72,14 @@ photosynthesis_outputs rue_photo(
     double const ci = Ca - an * (dr_boundary / gbw + dr_stomata / gs);  // dimensionless
 
     return photosynthesis_outputs{
-        .Assim = an * 1e6,                          // micromol / m^2 / s
-        .Assim_conductance = an_conductance * 1e6,  // micromol / m^2 / s
-        .Ci = ci * 1e6,                             // micromol / mol
-        .GrossAssim = ag * 1e6,                     // micromol / m^2 / s
-        .Gs = gs * 1e3,                             // mmol / m^2 / s
-        .Cs = BB_res.cs,                            // micromol / m^2 / s
-        .RHs = BB_res.hs,                           // dimensionless from Pa / Pa
-        .Rp = 0.0                                   // micromol / m^2 / s
+        /* .Assim = */ an * 1e6,                          // micromol / m^2 / s
+        /* .Assim_conductance = */ an_conductance * 1e6,  // micromol / m^2 / s
+        /* .Ci = */ ci * 1e6,                             // micromol / mol
+        /* .GrossAssim = */ ag * 1e6,                     // micromol / m^2 / s
+        /* .Gs = */ gs * 1e3,                             // mmol / m^2 / s
+        /* .Cs = */ BB_res.cs,                            // micromol / m^2 / s
+        /* .RHs = */ BB_res.hs,                           // dimensionless from Pa / Pa
+        /* .Rp = */ 0.0                                   // micromol / m^2 / s
     };
 }
 


### PR DESCRIPTION
See [my comment in issue #51](https://github.com/biocro/biocro/issues/51#issuecomment-1813828278) concerning this non-standard (in C++11) syntax.