### PR TITLE
stop echoing OBJECTS variable when running workflow on windows

### DIFF
--- a/.github/workflows/R-CMD-check-backend.yaml
+++ b/.github/workflows/R-CMD-check-backend.yaml
@@ -226,6 +226,17 @@ jobs:
 
         shell: Rscript {0}
 
+      - name: Modify winshlib.mk
+        if: ${{ matrix.os == 'windows-latest' && matrix.r == '3.6.0' }}
+        run: |
+          # Remove echoing of the OBJECTS variable, which seems to
+          # cause problems when using R 3.6 on Windows
+          sed '/echo.*\$(OBJECTS) /s/ \$(OBJECTS) / /' \
+              "C:/R/share/make/winshlib.mk" > "C:/R/share/make/winshlib.mk-tmp"
+          mv -f "C:/R/share/make/winshlib.mk-tmp" "C:/R/share/make/winshlib.mk"
+          cat "C:/R/share/make/winshlib.mk"
+        shell: bash
+
       - name: Check package
         if: ${{ !inputs.dry-run }}
         uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-check-backend.yaml
+++ b/.github/workflows/R-CMD-check-backend.yaml
@@ -234,7 +234,6 @@ jobs:
           sed '/echo.*\$(OBJECTS) /s/ \$(OBJECTS) / /' \
               "C:/R/share/make/winshlib.mk" > "C:/R/share/make/winshlib.mk-tmp"
           mv -f "C:/R/share/make/winshlib.mk-tmp" "C:/R/share/make/winshlib.mk"
-          cat "C:/R/share/make/winshlib.mk"
         shell: bash
 
       - name: Check package

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -52,14 +52,14 @@ on:
         description: 'Platform to check'
         type: choice
         options:
-          - R 3.6 on Ubuntu
+          - R 3.6.0 on Ubuntu
           - R release version on Ubuntu
           - R devel version on Ubuntu
-          - R 3.6 on macOS
+          - R 3.6.0 on macOS
           - R release version on macOS
-          - R 3.6 on Windows
+          - R 3.6.0 on Windows
           - R release version on Windows
-        default: R 3.6 on Ubuntu
+        default: R 3.6.0 on Ubuntu
 
 jobs:
 
@@ -83,12 +83,12 @@ jobs:
           # This filter uses the JMESPath query language to modify the
           # strategy matrix (see https://jmespath.org/).  Note that if
           # the event is anything other than 'workflow_dispatch', the
-          # filter condition is true only when configName is 'R 3.6 on
-          # Ubuntu'.
+          # filter condition is true only when configName is 'R 3.6.0
+          # on Ubuntu'.
           #
           # For the public version of this repository, the "&&
-          # configName = 'R 3.6 on Ubuntu'" clause will be eliminated
-          # so that when the event is anything other than
+          # configName = 'R 3.6.0 on Ubuntu'" clause will be
+          # eliminated so that when the event is anything other than
           # 'workflow_dispatch', the filter condition is always true
           # and nothing gets filtered out: all the configurations will
           # be run.
@@ -98,18 +98,18 @@ jobs:
           # matrix.  Thus, if the result of the filter is
           # [
           #   {
-          #     "configName": "R 3.6 on Ubuntu",
+          #     "configName": "R 3.6.0 on Ubuntu",
           #     "os": "ubuntu-20.04",
-          #     "r": "3.6"
+          #     "r": "3.6.0"
           #   }
           # ],
           # the actual output will be
           # { "include":
           #     [
           #       {
-          #         "configName": "R 3.6 on Ubuntu",
+          #         "configName": "R 3.6.0 on Ubuntu",
           #         "os": "ubuntu-20.04",
-          #         "r": "3.6"
+          #         "r": "3.6.0"
           #       }
           #     ]
           # }.       

--- a/.github/workflows/strategy_matrix.json
+++ b/.github/workflows/strategy_matrix.json
@@ -1,18 +1,18 @@
 [
     {
-        "configName": "R 3.6 on Windows",
+        "configName": "R 3.6.0 on Windows",
         "os": "windows-latest",
-        "r": "3.6"
+        "r": "3.6.0"
     },
     {
-        "configName": "R 3.6 on macOS",
+        "configName": "R 3.6.0 on macOS",
         "os": "macOS-latest",
-        "r": "3.6"
+        "r": "3.6.0"
     },
     {
-        "configName": "R 3.6 on Ubuntu",
+        "configName": "R 3.6.0 on Ubuntu",
         "os": "ubuntu-20.04",
-        "r": "3.6"
+        "r": "3.6.0"
     },
     {
         "configName": "R release version on Ubuntu",

--- a/NEWS.md
+++ b/NEWS.md
@@ -72,6 +72,14 @@ be directly added to this file to describe the related changes.
   - The debug output steps are grouped together when possible, and the
     output is shown earlier on in the workflow.
 
+  - The R-CMD-check workflow has been modified to work around a
+    problem with testing R version 3.6.0 on Windows.  And for all
+    platforms, we now specify the tested minimum R version as 3.6.0
+    rather than simply 3.6 in order to ensure that we are actually
+    testing the minimum required R version specified in the
+    DESCRIPTION file, rather than some later 3.6.x version such as
+    version 3.6.3.
+
 - Modified the R-CMD-check workflow so that the manual is not checked
   when the workflow runs automatically.  This has also been made the
   default when the workflow is run manually.


### PR DESCRIPTION
This fixes the problem with the R-CMD-check workflow running on Windows with R 3.6.0.  It also explicitly sets the R version for R 3.6 checks on _all_ platforms to 3.6.0 to match the minimum required R version specified in the DESCRIPTION file.

This is an alternative to PR #67.