### PR TITLE
Replace all fabs with std::abs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,11 +39,13 @@ be directly added to this file to describe the related changes.
   when using `git pull`, `git checkout`, or `git switch` to update a local copy
   of the BioCro repository, or to move to or from this branch.
 
-- Two bugs were corrected in `src/module_library/c3photoC.cpp`:
-  - Convergence is now tested using `fabs` rather than `abs`, since we need the
-    absolute value of a floating point number, not an integer.
-  - The photorespiration value `Rp` is now calculated using the value of `Ci`
-    from the current loop iteration (rather than the previous loop iteration).
+- All instances of `fabs` or unqualified `abs` have been replaced by `std::abs`.
+  The use of unqualified `abs` in `src/module_library/c3photoC.cpp` had been
+  causing test failures when running BioCro on Windows using R version 3.6.0.
+
+- Another bug was corrected in `src/module_library/c3photoC.cpp`: The
+  photorespiration value `Rp` is now calculated using the value of `Ci` from the
+  current loop iteration (rather than the previous loop iteration).
 
 - This version adds a description of the BioCro git branching model to
   `contribution_guidelines.Rmd` and clarifies the process of updating `NEWS.md`.

--- a/src/module_library/AuxBioCro.cpp
+++ b/src/module_library/AuxBioCro.cpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <stdexcept>  // for std::out_of_range, std::range_error
 #include <algorithm>  // for std::max, std::min
-#include <cmath>      // for exp, log, pow, lgamma
+#include <cmath>      // for exp, log, pow, lgamma, std::abs
 #include "c4photo.h"
 #include "BioCro.h"
 #include "water_and_air_properties.h"  // for saturation_vapor_pressure,
@@ -278,7 +278,7 @@ ET_Str EvapoTrans2(
             const double BottomValue = LHV * (SlopeFS + PsycParam * (1 + ga / conductance_in_m_per_s));           // J / m^3 / K
             Deltat = fmin(fmax(TopValue / BottomValue, -10), 10);                                                 // kelvin. Confine Deltat to the interval [-10, 10]:
 
-            ChangeInLeafTemp = fabs(OldDeltaT - Deltat);  // kelvin
+            ChangeInLeafTemp = std::abs(OldDeltaT - Deltat);  // kelvin
         } while ((++Counter <= 10) && (ChangeInLeafTemp > 0.5));
     }
 

--- a/src/module_library/biomass_leaf_n_limitation.h
+++ b/src/module_library/biomass_leaf_n_limitation.h
@@ -4,6 +4,7 @@
 #include "../framework/module.h"
 #include "../framework/state_map.h"
 #include "../framework/constants.h"  // For calculation_constants::eps_zero
+#include <cmath>                     // For std::abs
 
 namespace standardBML
 {
@@ -62,7 +63,7 @@ void biomass_leaf_n_limitation::do_operation() const
 {
     // Collect inputs and make calculations
     double leaf_n;
-    if (fabs((*Leaf_ip) + (*Stem_ip)) < calculation_constants::eps_zero) {
+    if (std::abs((*Leaf_ip) + (*Stem_ip)) < calculation_constants::eps_zero) {
         leaf_n = *LeafN_0_ip;
     } else {
         leaf_n = (*LeafN_0_ip) * pow((*Leaf_ip) + (*Stem_ip), -1.0 * (*kln_ip));

--- a/src/module_library/c3EvapoTrans.cpp
+++ b/src/module_library/c3EvapoTrans.cpp
@@ -1,4 +1,4 @@
-#include <cmath>
+#include <cmath>  // For std::abs
 #include <stdexcept>
 #include "c3photo.h"
 #include "BioCro.h"
@@ -102,7 +102,7 @@ struct ET_Str c3EvapoTrans(
             Deltat = TopValue / BottomValue;  // Kelvin. It is also degrees C, because it is a temperature difference.
             Deltat = std::min(std::max(Deltat, -5.0), 5.0);
 
-            ChangeInLeafTemp = fabs(OldDeltaT - Deltat);  // Kelvin. It is also degrees C, because it is a temperature difference.
+            ChangeInLeafTemp = std::abs(OldDeltaT - Deltat);  // Kelvin. It is also degrees C, because it is a temperature difference.
         }
     }
 

--- a/src/module_library/c3photo.cpp
+++ b/src/module_library/c3photo.cpp
@@ -1,4 +1,4 @@
-#include <cmath>                        // for pow, sqrt, fabs
+#include <cmath>                        // for pow, sqrt, std::abs
 #include <algorithm>                    // for std::min
 #include "ball_berry_gs.h"              // for ball_berry_gs
 #include "FvCB_assim.h"                 // for FvCB_assim
@@ -161,7 +161,7 @@ photosynthesis_outputs c3photoC(
         Ci = Ca - co2_assimilation_rate *
                       (dr_boundary / gbw + dr_stomata / Gs);  // micromol / mol
 
-        if (fabs(OldAssim - co2_assimilation_rate) < Tol) {
+        if (std::abs(OldAssim - co2_assimilation_rate) < Tol) {
             break;
         }
 

--- a/src/module_library/c4photo.cpp
+++ b/src/module_library/c4photo.cpp
@@ -1,4 +1,4 @@
-#include <cmath>                          // for pow, exp
+#include <cmath>                          // for pow, exp, std::abs
 #include "ball_berry_gs.h"                // for ball_berry_gs
 #include "conductance_limited_assim.h"    // for conductance_limited_assim
 #include "../framework/constants.h"       // for dr_stomata, dr_boundary
@@ -121,7 +121,7 @@ photosynthesis_outputs c4photoC(
             Ca_pa - atmospheric_pressure * (Assim * 1e-6) *
                         (dr_boundary / gbw + dr_stomata / (Gs * 1e-3));  // Pa
 
-        diff = fabs(OldAssim - Assim);  // micromole / m^2 / s
+        diff = std::abs(OldAssim - Assim);  // micromole / m^2 / s
 
         OldAssim = Assim;  // micromole / m^2 / s
 

--- a/src/module_library/rh_to_mole_fraction.h
+++ b/src/module_library/rh_to_mole_fraction.h
@@ -1,7 +1,7 @@
 #ifndef RH_TO_MOLE_FRACTION_H
 #define RH_TO_MOLE_FRACTION_H
 
-#include <cmath>                       // for fabs
+#include <cmath>                       // for std::abs
 #include "water_and_air_properties.h"  // for saturation_vapor_pressure
 #include "../framework/constants.h"    // for calculation_constants::eps_zero
 #include "../framework/module.h"
@@ -94,7 +94,7 @@ void rh_to_mole_fraction::do_operation() const
     // atmospheric_pressure == 0 causes a division by zero
     std::map<std::string, bool> errors_to_check = {
         {"atmospheric_pressure cannot be zero",
-         fabs(atmospheric_pressure) < calculation_constants::eps_zero}};
+         std::abs(atmospheric_pressure) < calculation_constants::eps_zero}};
 
     check_error_conditions(errors_to_check, get_name());
 


### PR DESCRIPTION
This PR replaces `fabs` and unqualified `abs` with `std::abs`.