### PR TITLE
Change some testing behavior

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -109,6 +109,12 @@ be directly added to this file to describe the related changes.
   `Rf_error` and `Rprintf` without a format specifier; a format specifier of
   `"%s"` should always be used when printing the value of a string variable.
 
+- Modified some testing-related functions so that warnings due to mismatched
+  framework versions do not trigger test failures: the `tryCatch` call in
+  `test_module` now only catches errors (not warnings) when evaluating the
+  module, and `test_plant_model` (in `crop_model_testing_helper_functions.R`)
+  now uses `expect_no_error` instead of `expect_silent`.
+
 # CHANGES IN BioCro VERSION 3.0.2
 
 ## MINOR CHANGES

--- a/R/module_testing.R
+++ b/R/module_testing.R
@@ -7,7 +7,7 @@ test_module <- function(module_name, case_to_test)
     msg <- character()
     actual_outputs <- tryCatch(
         evaluate_module(module_name, case_to_test[['inputs']]),
-        condition = function(cond) {
+        error = function(cond) {
             msg <<- paste0(
                 "Module `",
                 module_name,

--- a/tests/testthat/crop_model_testing_helper_functions.R
+++ b/tests/testthat/crop_model_testing_helper_functions.R
@@ -194,7 +194,7 @@ test_plant_model <- function(test_info) {
         # Run the simulation
         new_result <- 0
         test_that(description_run, {
-            expect_silent(
+            expect_no_error(
                 new_result <<- run_biocro(
                     test_info[['initial_values']],
                     test_info[['parameters']],


### PR DESCRIPTION
If an external module library based on `skelBML` uses a different version of the BioCro C++ framework than the version used by the `BioCro` R package, a warning will occur whenever a module is evaluated. The warning will say something like "The `edBML` module library R package uses a newer version of the BioCro C++ framework than the `BioCro` R package (1.2.1 vs. 1.1.1)." Such warnings should not be considered failures when testing modules as part of a package, since they are not related to a module's functionality. 

However, these warnings have been triggering test failures. (Thanks to @uphone87 for pointing this out.) The reason is that the `tryCatch` call in `BioCro::test_module` has been catching conditions (which includes errors _and_ warnings). Here I changed this behavior so `test_module` now only catches errors.

I also changed one of the crop model testing functions to use `expect_no_error` rather than `expect_silent` for the same reason.