### PR TITLE
Par energy content

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@ merged in since the previous release.
 Subsequent commits will then include a new "Unreleased" section in preparation
 for the next release.
 -->
+# Unreleased
+- Change the energy_par_content constant to 0.219. This is a conversion rate from photons to W/m2, which equals 1/4.57. 4.57 is a commonly used constant to convert PAR in W/m2 to micromol m-2 s-1. Users should be cautious when performing this conversion outside of BioCro to make sure the two are the same, for example, pre-processing the radiation data. See more details in Plant Growth Chamber Handbook. CHAPTER 1 – RADIATION– John C. Sager and J. Craig McFarlane. Table 2, Pg 3 (https://www.controlledenvironments.org/wp-content/uploads/sites/6/2017/06/Ch01.pdf) 
 
 # CHANGES IN BioCro VERSION 3.0.2
 

--- a/data/soybean.R
+++ b/data/soybean.R
@@ -116,7 +116,7 @@ soybean <- list(
 
         # incident_shortwave_from_ground_par module
         par_energy_fraction         = 0.5,
-        par_energy_content          = 0.235,
+        par_energy_content          = 0.219,       # Conversion from photons to W/m2. Equals 1/4.57. Plant Growth Chamber Handbook. CHAPTER 1 – RADIATION– John C. Sager and J. Craig McFarlane. Table 2, Pg 3 (https://www.controlledenvironments.org/wp-content/uploads/sites/6/2017/06/Ch01.pdf)
 
         # ten_layer_canopy_properties module
         absorptivity_par            = 0.8,         # Campbell and Norman, An Introduction to Environmental Biophysics, 2nd Edition


### PR DESCRIPTION
This PR makes the following changes,

- Change the par_energy_content constant to 0.219
- Update the related test file
- Update the NEWS

The current value of 0.235 is from an exercise example in the Campbell & Norman textbook, which may only represent an extremely clear sky. Here the more realistic 0.219 is the inverse of 4.57. 4.57 is a commonly used constant to convert PAR in W/m2 to &mu;mol m-2 s-1 as you would find in many references (e.g., [in Table 2 here](https://www.controlledenvironments.org/wp-content/uploads/sites/6/2017/06/Ch01.pdf)). No significant changes were found on assimilation and yield due to this change. About 1% of change was seen in the cumulative transpiration for soybean in 2002. This makes sense because the par_energy_content is used in the soil evaporation and evapotranspiration modules. The two modules need the radiation to be in W/m2, and thus we need the par_energy_content to make this conversion.