### PR TITLE
Remove cxx11

### DIFF
--- a/.github/workflows/strategy_matrix.json
+++ b/.github/workflows/strategy_matrix.json
@@ -3,6 +3,7 @@
         "configName": "R 3.6.0 on Windows",
         "os": "windows-latest",
         "r": "3.6.0"
+        "rtools-version": "40"
     },
     {
         "configName": "R 3.6.0 on macOS",

--- a/.github/workflows/strategy_matrix.json
+++ b/.github/workflows/strategy_matrix.json
@@ -2,8 +2,7 @@
     {
         "configName": "R 3.6.0 on Windows",
         "os": "windows-latest",
-        "r": "3.6.0",
-        "rtools-version": "40"
+        "r": "3.6.0"
     },
     {
         "configName": "R 3.6.0 on macOS",

--- a/.github/workflows/strategy_matrix.json
+++ b/.github/workflows/strategy_matrix.json
@@ -2,7 +2,7 @@
     {
         "configName": "R 3.6.0 on Windows",
         "os": "windows-latest",
-        "r": "3.6.0"
+        "r": "3.6.0",
         "rtools-version": "40"
     },
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Suggests:
     bookdown,
     lattice
 VignetteBuilder: knitr
-SystemRequirements: GNU make
+SystemRequirements: C++14, GNU make
 License: MIT + file LICENSE
 LazyData: true
 ByteCompile: TRUE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Suggests:
     bookdown,
     lattice
 VignetteBuilder: knitr
-SystemRequirements: C++11, GNU make
+SystemRequirements: GNU make
 License: MIT + file LICENSE
 LazyData: true
 ByteCompile: TRUE


### PR DESCRIPTION
There is an `R CMD check` note about requiring C++11. I looked into it a bit, and it seems that we do not need this anymore since we are not providing support for R v3.5 or lower: https://www.tidyverse.org/blog/2023/03/cran-checks-compiled-code/