### PR TITLE
Update documentation examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,8 @@ Suggests:
     knitr,
     rmarkdown,
     bookdown,
-    lattice
+    lattice,
+    deSolve
 VignetteBuilder: knitr
 SystemRequirements: C++11, GNU make
 License: MIT + file LICENSE

--- a/man/add_time_to_weather_data.Rd
+++ b/man/add_time_to_weather_data.Rd
@@ -5,12 +5,12 @@
 \title{Add a time component to input}
 
 \description{
-Ensure, if possible, that input data that varies over time has a "time"
-component.
+  Ensure, if possible, that input data that varies over time has a "time"
+  component.
 }
 
 \usage{
-add_time_to_weather_data(drivers)
+  add_time_to_weather_data(drivers)
 }
 
 \arguments{
@@ -21,17 +21,22 @@ add_time_to_weather_data(drivers)
 }
 
 \value{
-If drivers has no time component, then one is added, provided it \emph{does}
-have components for doy and hour. (The time values will be equal to the doy
-values plus the fractional portion of a day represented by the hour values.)
-Otherwise drivers is returned as is.
+  If drivers has no time component, then one is added, provided it \emph{does}
+  have components for doy and hour. (The time values will be equal to the doy
+  values plus the fractional portion of a day represented by the hour values.)
+  Otherwise drivers is returned as is.
 }
 
 \note{
-Preconditions: If drivers is a list, the values should be vectors of equal
-length.  Moreover, if it already contains a time component, then it shouldn't
-contain either a doy or an hour component unless it contains both of them and
-the values are mutually consistent.  Furthermore, the time represented by
-(doy, hour), if given, or by time, if given, should increase as the vector or
-row index increases.
+  Preconditions: If drivers is a list, the values should be vectors of equal
+  length.  Moreover, if it already contains a time component, then it shouldn't
+  contain either a doy or an hour component unless it contains both of them and
+  the values are mutually consistent.  Furthermore, the time represented by
+  (doy, hour), if given, or by time, if given, should increase as the vector or
+  row index increases.
+}
+
+\examples{
+  # Add a time column to the buit-in 2002 weather data
+  new_weather <- add_time_to_weather_data(weather[['2002']])
 }

--- a/man/dynamical_system.Rd
+++ b/man/dynamical_system.Rd
@@ -10,14 +10,14 @@
 }
 
 \usage{
-validate_dynamical_system_inputs(
-    initial_values = list(),
-    parameters = list(),
-    drivers,
-    direct_module_names = list(),
-    differential_module_names = list(),
-    verbose = TRUE
-)
+  validate_dynamical_system_inputs(
+      initial_values = list(),
+      parameters = list(),
+      drivers,
+      direct_module_names = list(),
+      differential_module_names = list(),
+      verbose = TRUE
+  )
 }
 
 \arguments{

--- a/man/get_growing_season_climate.Rd
+++ b/man/get_growing_season_climate.Rd
@@ -11,7 +11,7 @@
 }
 
 \usage{
-get_growing_season_climate(climate, threshold_temperature = 0)
+  get_growing_season_climate(climate, threshold_temperature = 0)
 }
 
 \arguments{
@@ -83,5 +83,17 @@ get_growing_season_climate(climate, threshold_temperature = 0)
 }
 
 \value{
-A copy of the \code{climate} data frame truncated to the growing season.
+  A copy of the \code{climate} data frame truncated to the growing season.
+}
+
+\examples{
+  # Truncate the 2002 Champaign, Illinois weather data to an estimated growing
+  # season
+  truncated_weather <- get_growing_season_climate(weather[['2002']])
+
+  # We can see which days were included
+  list(
+    doy_start = min(truncated_weather$doy),
+    doy_end = max(truncated_weather$doy)
+  )
 }

--- a/man/module_case_files.Rd
+++ b/man/module_case_files.Rd
@@ -142,7 +142,7 @@ initialize_csv(
   overwrite = TRUE
 )
 
-file.show(file.path(td, 'BioCro_thermal_time_linear.csv'))
+writeLines(readLines(file.path(td, 'BioCro_thermal_time_linear.csv')))
 
 add_csv_row(
   'BioCro:thermal_time_linear',
@@ -151,7 +151,7 @@ add_csv_row(
   'temp above tbase'
 )
 
-file.show(file.path(td, 'BioCro_thermal_time_linear.csv'))
+writeLines(readLines(file.path(td, 'BioCro_thermal_time_linear.csv')))
 
 update_csv_cases('BioCro:thermal_time_linear', td)
 }

--- a/man/module_case_files.Rd
+++ b/man/module_case_files.Rd
@@ -127,28 +127,31 @@
 
 \examples{
 # First, we will initialize a test case file for the 'BioCro' library's
-# 'thermal_time_linear' module, which will be saved in the current directory as
+# 'thermal_time_linear' module, which will be saved in a temporary directory as
 # 'BioCro_thermal_time_linear.csv'. Then, we will add a new case to the file.
 # Finally, we will update the file. Note that the call to `update_csv_cases`
 # will not actually modify the file unless it is manually edited beforehand to
 # change an input or output value.
 
-\dontrun{
+td <- tempdir()
 
 initialize_csv(
   'BioCro:thermal_time_linear',
-  '.',
+  td,
   nonstandard_inputs = list(temp = -1),
   overwrite = TRUE
 )
 
+file.show(file.path(td, 'BioCro_thermal_time_linear.csv'))
+
 add_csv_row(
   'BioCro:thermal_time_linear',
-  '.',
+  td,
   list(time = 101, sowing_time = 100, tbase = 20, temp = 44),
   'temp above tbase'
 )
 
-update_csv_cases('BioCro:thermal_time_linear', '.')
-}
+file.show(file.path(td, 'BioCro_thermal_time_linear.csv'))
+
+update_csv_cases('BioCro:thermal_time_linear', td)
 }

--- a/man/module_creators.Rd
+++ b/man/module_creators.Rd
@@ -6,7 +6,9 @@
 
 \description{Creates pointers to module wrapper objects}
 
-\usage{module_creators(module_names)}
+\usage{
+  module_creators(module_names)
+}
 
 \arguments{
   \item{module_names}{A vector of module names}

--- a/man/module_paste.Rd
+++ b/man/module_paste.Rd
@@ -10,7 +10,9 @@
   \code{\link{run_biocro}} or other BioCro functions.
 }
 
-\usage{module_paste(lib_name, local_module_names)}
+\usage{
+  module_paste(lib_name, local_module_names)
+}
 
 \arguments{
   \item{lib_name}{A string specifying a module library name.}

--- a/man/run_biocro.Rd
+++ b/man/run_biocro.Rd
@@ -7,15 +7,15 @@
 \description{Runs a full crop growth simulation using the BioCro framework}
 
 \usage{
-run_biocro(
-    initial_values = list(),
-    parameters = list(),
-    drivers,
-    direct_module_names = list(),
-    differential_module_names = list(),
-    ode_solver = BioCro::default_ode_solvers$homemade_euler,
-    verbose = FALSE
-)
+  run_biocro(
+      initial_values = list(),
+      parameters = list(),
+      drivers,
+      direct_module_names = list(),
+      differential_module_names = list(),
+      ode_solver = BioCro::default_ode_solvers$homemade_euler,
+      verbose = FALSE
+  )
 }
 
 \arguments{

--- a/man/system_derivatives.Rd
+++ b/man/system_derivatives.Rd
@@ -83,9 +83,7 @@ soybean_system <- system_derivatives(
 
 derivs <- soybean_system(0, unlist(soybean$initial_values), NULL)
 
-# Example 2: a simple oscillator with only one module (requires deSolve)
-
-\dontrun{
+# Example 2: a simple oscillator with only one module
 
 times = seq(0, 5, length=100)
 
@@ -112,13 +110,11 @@ lattice::xyplot(
   auto=TRUE,
   data=result
 )
-}
 
-# Example 3: solving 500 hours of a soybean simulation. This requires the
-# deSolve package and will run very slow compared to a regular call to
-# `run_biocro`.
+# Example 3: solving 500 hours of a soybean simulation. This will run very slow
+# compared to a regular call to `run_biocro`.
 
-\dontrun{
+\donttest{
 
 soybean_system <- system_derivatives(
   soybean$parameters,

--- a/man/system_derivatives.Rd
+++ b/man/system_derivatives.Rd
@@ -10,12 +10,12 @@
 }
 
 \usage{
-system_derivatives(
-  parameters = list(),
-  drivers,
-  direct_module_names = list(),
-  differential_module_names = list()
-)
+  system_derivatives(
+    parameters = list(),
+    drivers,
+    direct_module_names = list(),
+    differential_module_names = list()
+  )
 }
 
 \arguments{

--- a/man/system_derivatives.Rd
+++ b/man/system_derivatives.Rd
@@ -36,7 +36,7 @@
   }
 }
 
-\value{
+\details{
   \code{system_derivatives} accepts the same input arguments as
   \code{\link{run_biocro}} with the exceptions of \code{ode_solver} and
   \code{initial_values}; this function is intended to be passed to an ODE solver
@@ -44,6 +44,13 @@
   quantities evolve from their initial values, so \code{ode_solver} and
   \code{initial_values} are not required here.
 
+  When using one of the pre-defined crop growth models, it may be helpful to
+  use the \code{with} command to pass arguments to \code{system_derivatives};
+  see the documentation for \code{\link{crop_model_definitions}} for more
+  information.
+}
+
+\value{
   The return value of \code{system_derivatives} is a function with three inputs
   (\code{t}, \code{differential_quantities}, and \code{parms}) that returns
   derivatives for each of the differential quantities in the dynamical system
@@ -60,11 +67,6 @@
 
   This function can be passed to \code{LSODES} as an alternative integration
   method, rather than using one of BioCro's built-in solvers.
-
-  When using one of the pre-defined crop growth models, it may be helpful to
-  use the \code{with} command to pass arguments to \code{system_derivatives};
-  see the documentation for \code{\link{crop_model_definitions}} for more
-  information.
 }
 
 \seealso{
@@ -72,6 +74,8 @@
 }
 
 \examples{
+# Note: Example 3 below may take several minutes to run. Patience is required!
+
 # Example 1: calculating a single derivative using a soybean model
 
 soybean_system <- system_derivatives(
@@ -111,7 +115,7 @@ lattice::xyplot(
   data=result
 )
 
-# Example 3: solving 500 hours of a soybean simulation. This will run very slow
+# Example 3: solving 500 hours of a soybean simulation. This will run slowly
 # compared to a regular call to `run_biocro`.
 
 \donttest{

--- a/man/test_module.Rd
+++ b/man/test_module.Rd
@@ -136,13 +136,12 @@ test_module(
 
 # Example 3: Loading a set of test cases from a file and running one of them.
 # Note: here we use the `initialize_csv` function first to ensure that there is
-# a properly defined test file in the current directory.
+# a properly defined test file in a temporary directory.
 
-\dontrun{
+td <- tempdir()
 
 module_name <- 'BioCro:thermal_time_linear'
-initialize_csv(module_name, '.')
-cases <- cases_from_csv(module_name, '.')
+initialize_csv(module_name, td)
+cases <- cases_from_csv(module_name, td)
 test_module(module_name, cases[[1]])
-}
 }

--- a/man/test_module_library.Rd
+++ b/man/test_module_library.Rd
@@ -12,7 +12,7 @@
 }
 
 \usage{
-test_module_library(library_name, directory, modules_to_skip = c())
+  test_module_library(library_name, directory, modules_to_skip = c())
 }
 
 \arguments{
@@ -40,6 +40,10 @@ test_module_library(library_name, directory, modules_to_skip = c())
   For an example of how this function can be used along with the
   \code{\link[testthat]{testthat}} package, see
   \code{tests/testthat/test.Modules.R}.
+}
+
+\value{
+  None
 }
 
 \seealso{

--- a/man/test_module_library.Rd
+++ b/man/test_module_library.Rd
@@ -54,3 +54,34 @@
     \item \code{\link{test_module}}
   }
 }
+
+\examples{
+# Here we will initialize a module test case file in a temporary directory, and
+# then use `test_module_library` to test it. We will need to skip most of the
+# modules in the library, since we only have a test case for one of them.
+
+td <- tempdir()
+
+initialize_csv(
+  'BioCro:thermal_time_linear',
+  td,
+  nonstandard_inputs = list(temp = -1),
+  overwrite = TRUE
+)
+
+# Get a list of local module names, excluding the module that has a test case
+all_modules <- get_all_modules('BioCro')
+skip <- all_modules[all_modules != 'BioCro:thermal_time_linear']
+skip <- gsub('BioCro:', '', skip)
+
+test_module_library('BioCro', td, skip)
+
+# If we attempt to test the entire library, we will get errors since only one
+# module actually has an associated case file
+tryCatch(
+  {
+    test_module_library('BioCro', td)
+  },
+  error = function(e) {print(e)}
+)
+}


### PR DESCRIPTION
One of the requirements listed in the "R Packages" advice page (https://r-pkgs.org/release.html) is to make sure all exported functions have documentation that includes `value` and `examples`. I found a few functions that didn't meet these requirements, and also standardized some formatting (just indentation).

Functions related to creating and testing module case files were a bit tricky. I looked at the documentation for `write.csv` to see how its examples work. They use `tempdir`, so I tried that out and it seems to work well (pending the results from the GitHub action checks).

----

We might need to still do something about the examples for `system_derivatives`, which are currently wrapped in `dontrun` because they require the `deSolve` library and are also very slow. I'm a bit unsure about this. Apparently the CRAN policy is that:

> Examples/code lines in examples should never be commented out.
> Ideally find toy examples that can be regularly executed and checked.
> Lengthy examples (\> 5 sec), can be wrapped in `\donttest{}`.
> If you don't want your code to be executed but still visible to the user, use `\dontrun{}`.

It seems that `donttest` may be more appropriate for these examples, but then I think we would need to add `deSolve` to the `Suggests` for our package. That might be reasonable, since the documentation for `system_derivatives` mentions `deSolve` several times. Alternatively, we could remove these examples altogether, or use a really simple Euler method to solve them (which wouldn't require any other packages). Or we can just leave them as-is and see if they are a problem for CRAN. What do you think?