### PR TITLE
Reduce package size

### DIFF
--- a/tests/testthat/crop_model_testing_helper_functions.R
+++ b/tests/testthat/crop_model_testing_helper_functions.R
@@ -100,11 +100,15 @@ SOYBEAN_IGNORE <- c(
     "sunlit_EPriestly_layer_9"
 )
 
+# Change the output step size for the soybean simulation
+soybean_test <- soybean
+soybean_test$ode_solver$output_step_size <- 6
+
 # Define the plants to test
 PLANT_TESTING_INFO <- list(
     specify_crop("miscanthus_x_giganteus", TRUE,  miscanthus_x_giganteus, WEATHER,                MISCANTHUS_X_GIGANTEUS_IGNORE), # INDEX = 1
     specify_crop("willow",                 TRUE,  willow,                 WEATHER,                WILLOW_IGNORE),                 # INDEX = 2
-    specify_crop("soybean",                TRUE,  soybean,                soybean_weather$'2002', SOYBEAN_IGNORE)                 # INDEX = 3
+    specify_crop("soybean",                TRUE,  soybean_test,           soybean_weather$'2002', SOYBEAN_IGNORE)                 # INDEX = 3
 )
 
 # Make a helping function that runs a simulation for one crop
@@ -164,6 +168,8 @@ update_stored_results <- function(test_info) {
 # Make a helping function that checks the result of a new simulation against the
 # stored data for one crop
 test_plant_model <- function(test_info) {
+    # Read the stored result from the data file
+    stored_result <- read.csv(test_info[['stored_result_file']])
 
     # Describe the current test
     description_validity <- paste(
@@ -217,7 +223,7 @@ test_plant_model <- function(test_info) {
         )
 
         test_that(description, {
-            expect_equal(nrow(new_result), nrow(test_info[['drivers']]))
+            expect_equal(nrow(new_result), nrow(stored_result))
         })
 
         # If the simulation finished, make additional checks
@@ -243,9 +249,6 @@ test_plant_model <- function(test_info) {
                     warning(msg)
                 }
             }
-
-            # Read the stored result from the data file
-            stored_result <- read.csv(test_info[['stored_result_file']])
 
             # Make sure all columns contain numeric data
             stored_result <- as.data.frame(sapply(stored_result, as.numeric))


### PR DESCRIPTION
Just following up on something from the email thread. I looked into changing the output step size for the soybean regression test. It looks like the results are pretty consistent across a range of step sizes. This can be checked with the following code:
```r
library(BioCro)
library(lattice)

test_step_size <- function(step_size) {
    res <- with(soybean, {run_biocro(
        initial_values,
        parameters,
        soybean_weather[['2002']],
        direct_modules,
        differential_modules,
        within(ode_solver, {output_step_size = step_size})
    )})
    
    res$output_step_size <- step_size
    res$final_pod <- res[nrow(res), 'Grain']
    res$nrow <- nrow(res)
    res
}

step_size_seq <- c(1, 2, 3, 6, 9, 12, 18, 24)

full_res <- do.call(rbind, lapply(step_size_seq, test_step_size))

xyplot(
    Leaf + Stem + Root + Grain ~ time,
    group = output_step_size,
    data = full_res,
    type = 'l',
    auto = TRUE
)

dev.new()
xyplot(
    final_pod ~ output_step_size,
    data = unique(full_res[, c('final_pod', 'output_step_size')]),
    type = 'p',
    pch = 16
)

dev.new()
xyplot(
    nrow ~ output_step_size,
    data = unique(full_res[, c('nrow', 'output_step_size')]),
    type = 'p',
    pch = 16
)
```

Here are the plots I see:

![image](https://github.com/biocro/biocro/assets/48919455/3af8e099-8483-4547-ad6b-020231930a52)

![image](https://github.com/biocro/biocro/assets/48919455/e08b9ef7-f414-4d8e-9ec8-fd95040a62be)

![image](https://github.com/biocro/biocro/assets/48919455/35205464-f701-4ee2-aed3-e4e42f14bd41)

In this PR, I changed the output step to 6. This reduces the stored test result CSV to 1/6 of its original size. I want to see if the tests pass on all OSes. I suspect that differences in rounding on different OSes may become more pronounced with a larger output step size.

I think this will be another hotfix so I am requesting to merge into `main`. I haven't updated `NEWS` or the version yet in case we want to make other changes, or in case this fails on other OSes.