### PR TITLE
modify growth_respiration_fraction based on assim's sign

### DIFF
--- a/src/module_library/multilayer_canopy_integrator.h
+++ b/src/module_library/multilayer_canopy_integrator.h
@@ -184,7 +184,11 @@ void multilayer_canopy_integrator::run() const
     // Note: this was originally only done for the C3 canopy
     // Note: it seems like this should not be necessary since the assimilation
     //   model includes respiration
-    canopy_assimilation_rate *= (1.0 - growth_respiration_fraction);
+    if(canopy_assimilation_rate>0){
+      canopy_assimilation_rate *= (1.0 - growth_respiration_fraction);
+    }else{
+      canopy_assimilation_rate *= (1.0 + growth_respiration_fraction);
+    }
 
     // For assimilation, we need to convert micromol / m^2 / s into
     // Mg / ha / hr, assuming that all carbon is converted into biomass in the

--- a/src/module_library/multilayer_canopy_integrator.h
+++ b/src/module_library/multilayer_canopy_integrator.h
@@ -1,6 +1,7 @@
 #ifndef MULTILAYER_CANOPY_INTEGRATOR_H
 #define MULTILAYER_CANOPY_INTEGRATOR_H
 
+#include <cmath>  // for fabs
 #include "../framework/state_map.h"
 #include "../framework/module.h"
 #include "../framework/constants.h"  // for molar_mass_of_water, molar_mass_of_glucose
@@ -184,11 +185,11 @@ void multilayer_canopy_integrator::run() const
     // Note: this was originally only done for the C3 canopy
     // Note: it seems like this should not be necessary since the assimilation
     //   model includes respiration
-    if(canopy_assimilation_rate>0){
-      canopy_assimilation_rate *= (1.0 - growth_respiration_fraction);
-    }else{
-      canopy_assimilation_rate *= (1.0 + growth_respiration_fraction);
-    }
+    double const growth_respiration =
+        growth_respiration_fraction * fabs(canopy_assimilation_rate);  // micromol / m^2 / s
+
+    canopy_assimilation_rate =
+        canopy_assimilation_rate - growth_respiration;  // micromol / m^2 / s
 
     // For assimilation, we need to convert micromol / m^2 / s into
     // Mg / ha / hr, assuming that all carbon is converted into biomass in the


### PR DESCRIPTION
The growth respiration fraction is applied to reduce the canopy assimilation. Although it is set to be 0 at default, I'm proposing this minor fix for future use. 
When canopy assimilation is negative (e.g., respiration at night), this fraction would lower the respiration. 
Based on my understanding, I think when canopy assimilation is negative, the growth_respiration_fraction should be added instead of being subtracted.