### PR TITLE
Change r cmd check

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -70,7 +70,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -76,7 +76,7 @@ jobs:
 
       - id: set-matrix
         name: Construct the strategy matrix
-        uses: JoshuaTheMiller/conditional-build-matrix@81b51eb8d89e07b86404934b5fecde1cea1163a5 # release 2.0.1
+        uses: JoshuaTheMiller/conditional-build-matrix@main
         with:
           inputFile: '.github/workflows/strategy_matrix.json'
 
@@ -105,7 +105,7 @@ jobs:
           #         "r": "3.6.0"
           #       }
           #     ]
-          # }.       
+          # }.
           filter:
             '[?configName == `${{ inputs.platform-to-check }}`
                 || `${{ github.event_name }}` != ''workflow_dispatch'']'
@@ -125,7 +125,7 @@ jobs:
     needs: matrix_prep
     with:
       strategy-matrix: ${{ needs.matrix_prep.outputs.matrix }}
-      
+
       # Note: Non-manual dispatches automatically run the tests and
       # check the examples and the vignettes, but do not check the
       # manual.  Note that the inputs.* values will have non-boolean

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -65,7 +65,7 @@ jobs:
         echo "VERSION=${GITHUB_REF_NAME////_}" >> $GITHUB_ENV
 
     - name: 1. Check out repository
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -114,7 +114,7 @@ jobs:
 
     - name: 7a. Check out the target "PUBLISH_TO" repository
       if: inputs.publish
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4
       with:
         repository: ${{ env.PUBLISH_TO }}
         path: ${{ env.BIOCRO_DOCUMENTATION_ROOT }}

--- a/.github/workflows/document_quantities.yml
+++ b/.github/workflows/document_quantities.yml
@@ -20,7 +20,7 @@ jobs:
     # Checks out this repository under $GITHUB_WORKSPACE/source:
 
     - name: 1. Check out master
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4
       with:
         submodules: true
         path: source
@@ -87,7 +87,7 @@ jobs:
     # check in our changes later, in the Push step:
 
     - name: 10. Check out master of the "publish-to" repository
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4
       with:
         repository: ${{ env.publish-to }}
         path: target


### PR DESCRIPTION
There have been some recent errors with the `R CMD check` workflow such as the following:

```
Error: Bad request - quarto-dev/quarto-actions/setup@577558713f28cb3a0e7a735f80dce913d89b77d2 is not allowed to be used in biocro/biocro. Actions in this workflow must be: within a repository owned by biocro, created by GitHub, or matching the following: JoshuaTheMiller/conditional-build-matrix@81b51eb8d89e07b86404934b5fecde1cea1163a5, r-lib/actions/*@v2.
```

I'm not quite sure what to make of it, but I looked for examples using `JoshuaTheMiller/conditional-build-matrix` and noticed a few small differences compared to our code. This is just a shot in the dark to see if it fixes the problem.