### PR TITLE
Use upload-artifact v4.4.3

### DIFF
--- a/.github/actions/build_pkgdown_site/action.yml
+++ b/.github/actions/build_pkgdown_site/action.yml
@@ -14,6 +14,12 @@ runs:
     - name: Install Pandoc
       uses: r-lib/actions/setup-pandoc@v2
 
+    - name: Install R
+      uses: r-lib/actions/setup-r@v2
+      with:
+        r-version: "release"
+        use-public-rspm: true
+
     - name: Install TinyTex
       run: |
         install.packages('tinytex')

--- a/.github/actions/render_bookdown_book/action.yml
+++ b/.github/actions/render_bookdown_book/action.yml
@@ -17,12 +17,18 @@ runs:
       if: steps.pandoc-test.outcome == 'failure'
       uses: r-lib/actions/setup-pandoc@v2
 
-    - name: 3. Install bookdown
+    - name: 3. Install R
+      uses: r-lib/actions/setup-r@v2
+      with:
+        r-version: "release"
+        use-public-rspm: true
+
+    - name: 4. Install bookdown
       run: |
         install.packages(c("bookdown"))
       shell: Rscript {0}
 
-    - name: 4. Run bookdown
+    - name: 5. Run bookdown
       working-directory: ${{ inputs.package_root }}/documentation/script
       run: |
         Rscript run_bookdown.R

--- a/.github/workflows/R-CMD-check-backend.yaml
+++ b/.github/workflows/R-CMD-check-backend.yaml
@@ -80,6 +80,12 @@ jobs:
       args: ${{ steps.compute-args.outputs.args }}
       error_on: ${{ steps.compute-args.outputs.error_on }}
     steps:
+      - name: Install R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: "release"
+          use-public-rspm: true
+
       - id: compute-args
         name: Compute args
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -105,7 +105,7 @@ jobs:
           #         "r": "3.6.0"
           #       }
           #     ]
-          # }.       
+          # }.
           filter:
             '[?configName == `${{ inputs.platform-to-check }}`
                 || `${{ github.event_name }}` != ''workflow_dispatch'']'
@@ -125,7 +125,7 @@ jobs:
     needs: matrix_prep
     with:
       strategy-matrix: ${{ needs.matrix_prep.outputs.matrix }}
-      
+
       # Note: Non-manual dispatches automatically run the tests and
       # check the examples and the vignettes, but do not check the
       # manual.  Note that the inputs.* values will have non-boolean

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -201,8 +201,8 @@ jobs:
 
     - name: 11. Upload artifact containing documentation
       if: always() # Even if some steps fail, at least try to make a documentation artifact.
-      uses: actions/upload-artifact@v3.1.3
+      uses: actions/upload-artifact@v4.4.3
       with:
-        name: biocro-documentation
+        name: biocro-documentation-${{ env.VERSION }}
         path: biocro-docs-from-${{ env.VERSION }}.tgz
         retention-days: 3


### PR DESCRIPTION
This PR attempts to address issue https://github.com/biocro/biocro/issues/132

We only use `upload-artifact` in one spot (in the documentation workflow). The workflow had been using version 3.1.3 of the action, so I changed it to the latest version (4.4.3).

I also followed the instructions in the "Multiple uploads to the same named Artifact" section here: https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md. I think that section seems to apply for our situation.