### PR TITLE
`run_biocro` checks if provided `time` variable is consistent with the provided `timestep` and the output from a biocro simulation.

### DIFF
--- a/R/add_time_to_weather_data.R
+++ b/R/add_time_to_weather_data.R
@@ -4,8 +4,7 @@ add_time_to_weather_data <- function(drivers)
         "hour" %in% names(drivers) &&
         !"time" %in% names(drivers))
     {
-        day_fraction <- drivers$hour / 24.0
-        drivers$time <- drivers$doy + day_fraction
+        drivers$time <- 24.0 * drivers$doy + drivers$hour
     }
 
     drivers

--- a/R/input_checking_functions.R
+++ b/R/input_checking_functions.R
@@ -272,3 +272,31 @@ check_boolean <- function(args_to_check) {
     }
     return(error_message)
 }
+
+# Checks whether the `time` driver has
+check_time_is_correct_format <- function(drivers, parameters, rtol = sqrt(.Machine$double.eps)){
+    time_is_null <- is.null(drivers[['time']])
+    if(time_is_null){
+        error_message <- "No `time` variable found in the `drivers` dataframe."
+        return(error_message)
+    }
+    time <- drivers[['time']]
+    timestep <- parameters[['timestep']]
+
+    diff_days = diff(time)
+    diff_hours = diff_days  * 24
+    dt = diff(time) * 24 - timestep
+    is_zero = abs(dt) < rtol
+    not_all_zero = !all(is_zero)
+    if(not_all_zero){
+        error_message <- "
+        The `time` variable is not a sequence of integer multiples of the `timestep`.\n
+        `time` should satisfy: t[n] = t[1] + timestep * (n-1)"
+
+        return(error_message)
+    }
+
+    error_message <- character()
+    return(error_message)
+
+}

--- a/R/input_checking_functions.R
+++ b/R/input_checking_functions.R
@@ -286,8 +286,8 @@ check_time_is_correct_format <- function(drivers, parameters, rtol = sqrt(.Machi
     timestep <- parameters[['timestep']]
 
     diff_days = diff(time)
-    diff_hours = diff_days  * 24
-    dt = diff(time) * 24 - timestep
+    diff_hours = diff_days
+    dt = diff(time) - timestep
     is_zero = abs(dt) < rtol
     not_all_zero = !all(is_zero)
     if(not_all_zero){

--- a/R/input_checking_functions.R
+++ b/R/input_checking_functions.R
@@ -273,7 +273,9 @@ check_boolean <- function(args_to_check) {
     return(error_message)
 }
 
-# Checks whether the `time` driver has
+# Checks that the `time` variable is strictly increasing and evenly spaced with the `timestep`.
+# The check is t[n] - t[n-1] == timestep / 24 up to error tolerance due to
+# inexact floating point arithmetic.
 check_time_is_correct_format <- function(drivers, parameters, rtol = sqrt(.Machine$double.eps)){
     time_is_null <- is.null(drivers[['time']])
     if(time_is_null){
@@ -291,7 +293,7 @@ check_time_is_correct_format <- function(drivers, parameters, rtol = sqrt(.Machi
     if(not_all_zero){
         error_message <- "
         The `time` variable is not a sequence of integer multiples of the `timestep`.\n
-        `time` should satisfy: t[n] = t[1] + timestep * (n-1)"
+        `time` should satisfy: t[n] = t[1] + timestep / 24 * (n-1)"
 
         return(error_message)
     }

--- a/R/run_biocro.R
+++ b/R/run_biocro.R
@@ -96,6 +96,16 @@ check_run_biocro_inputs <- function(
         )
     )
 
+    # The `time` variable in the `drivers` should be sequential and sorted, with
+    # no repeated times. Checks that `time` satisfies t[n] = t[1] + (n-1) * timestep
+    error_message <- append(
+        error_message,
+        check_time_is_correct_format(
+            drivers,
+            parameters
+        )
+    )
+
     # The direct_module_names and differential_module_names should be vectors or
     # lists of strings. The ode_solver's `type` element should also be a string.
     error_message <- append(

--- a/R/run_biocro.R
+++ b/R/run_biocro.R
@@ -145,6 +145,10 @@ run_biocro <- function(
     verbose = FALSE
 )
 {
+
+    # If the drivers input doesn't have a time column, add one
+    drivers <- add_time_to_weather_data(drivers)
+
     # Check over the inputs arguments for possible issues
     error_messages <- check_run_biocro_inputs(
         initial_values,
@@ -157,9 +161,6 @@ run_biocro <- function(
     )
 
     send_error_messages(error_messages)
-
-    # If the drivers input doesn't have a time column, add one
-    drivers <- add_time_to_weather_data(drivers)
 
     # Make module creators from the specified names and libraries
     direct_module_creators <- sapply(

--- a/R/validate_dynamical_system_inputs.R
+++ b/R/validate_dynamical_system_inputs.R
@@ -7,6 +7,9 @@ validate_dynamical_system_inputs <- function(
     verbose = TRUE
 )
 {
+    # If the drivers input doesn't have a time column, add one
+    drivers <- add_time_to_weather_data(drivers)
+
     # The inputs to this function have the same requirements as the `run_biocro`
     # inputs with the same names
     error_messages <- check_run_biocro_inputs(
@@ -19,9 +22,6 @@ validate_dynamical_system_inputs <- function(
     )
 
     send_error_messages(error_messages)
-
-    # If the drivers input doesn't have a time column, add one
-    drivers <- add_time_to_weather_data(drivers)
 
     # Make module creators from the specified names and libraries
     direct_module_creators <- sapply(

--- a/src/module_library/solar_position_michalsky.h
+++ b/src/module_library/solar_position_michalsky.h
@@ -160,7 +160,7 @@ string_vector solar_position_michalsky::get_inputs()
     return {
         "lat",               // degrees (North is positive)
         "longitude",         // degrees (East is positive)
-        "time",              // time expressed as a fractional day of year
+        "time",              // time expressed as an hour
         "time_zone_offset",  // the offset of the time zone relative to UTC
         "year"               // a year between 1950 and 2050
     };
@@ -197,9 +197,9 @@ void solar_position_michalsky::do_operation() const
     double constexpr jd_ref_2000 = 2451545.0;  // Julian date at noon on 1 January 2000 (UTC)
 
     // Unpack the doy and hour in UTC
-    double time_utc = time - time_zone_offset / hr_per_day;     // days
-    double const doy_utc = floor(time_utc);                     // days
-    double const hour_utc = hr_per_day * (time_utc - doy_utc);  // hours
+    double time_utc = time - time_zone_offset ;     // hours
+    double const doy_utc = floor(time_utc / hr_per_day);   // days
+    double const hour_utc = time_utc - doy_utc;  // hours
 
     // Calculate the Julian date
     double const delta = year - 1949.0;

--- a/src/module_library/soybean_development_rate_calculator.h
+++ b/src/module_library/soybean_development_rate_calculator.h
@@ -118,7 +118,7 @@ class soybean_development_rate_calculator : public direct_module
 string_vector soybean_development_rate_calculator::get_inputs()
 {
     return {
-        "time",             // days
+        "time",             // hours
         "sowing_time",      // days
         "maturity_group",   // dimensionless; maturity group of soybean cultivar
         "DVI",              // dimensionless; development index, see Osborne et al. 2015
@@ -149,8 +149,8 @@ string_vector soybean_development_rate_calculator::get_outputs()
 void soybean_development_rate_calculator::do_operation() const
 {
     double soybean_development_rate;  // day^-1
-
-    if (time < sowing_time) {
+    double hour_per_day = 24.0;
+    if (time/hour_per_day < sowing_time) {
         // The seeds haven't been sown yet, so no development should occur
         soybean_development_rate = 0;  // day^-1
     } else if (DVI < -1) {


### PR DESCRIPTION
Pull request to patch the "bug" described in issue #129 

As part of the other input checks, `run_biocro` will now check whether the `time` variable is evenly spaced by `timestep`. It will raise an error, if any of the following conditions occur:

1. Times are repeated: e.g `t = [0, 1, 1, 3, 4, 5]`
2. Times are not sequential (sorted): e.g. `t = [2, 1, 4, 5, 3]`
3. Times are not consistent with the timestep: e.g. `t = [0, 2, 4, 6]` instead of `t = [0, 1, 2, 3]` if `timestep = 1`.

However, there's a minor complication. The `time` variable is in days while `timestep` is assumed to be hours. The conversion is hard coded so this code has that assumption hard coded as well. That is, the code checks that `24 * ( t[n] - t[n-1]) == timestep ` (up to an error tolerance). 

It might be preferable to make `time` have the same units as `timestep` (so hours) then clients could convert `time` to other time units.  This check would have to change.  