### PR TITLE
Add more advice about building vignettes

### DIFF
--- a/developer_documentation/contribution_guidelines.Rmd
+++ b/developer_documentation/contribution_guidelines.Rmd
@@ -206,10 +206,10 @@ found to be helpful.
 * **Submitted code should work:** It takes time and effort to produce a
   thoughtful review of a pull request, so requests to review a PR should
   generally only be made for working code. In a BioCro context, "working" code
-  means that `R CMD check` does not produce any errors. See the
-  ["Running R CMD check" chapter](#r-cmd-check) for more information. While
-  passing `R CMD check` does not guarantee that the new code achieves its goals,
-  is fully documented, or follows the coding style guidelines, it is
+  means that `R CMD check` does not produce any errors and that all the
+  vignettes can be built. See the ["Running R CMD check" chapter](#r-cmd-check)
+  for more information. While this does not guarantee that the new code achieves
+  its goals, is fully documented, or follows the coding style guidelines, it is
   nevertheless a minimum requirement for any code to be incorporated into
   BioCro. The following is a thorough workflow that should ensure submitted code
   is working:
@@ -222,21 +222,31 @@ found to be helpful.
 
   2. When all the regression tests are passing, run `R CMD check` locally. This
      takes longer than just running the regression tests, but it will also make
-     sure that all code in the examples and vignettes is able to run, which
-     sometimes turns up more issues.
+     sure that all code in the examples (and some of the vignettes) is able to
+     run, which sometimes turns up more issues.
 
      Instructions for running `R CMD check` locally can be found in
-     ["Running R CMD check locally"](#sec:local-r-cmd-check) (Section
-     \@ref(sec:local-r-cmd-check)).
+     ["Running R CMD check locally" section](#sec:local-r-cmd-check).
 
-  3. When `R CMD check` is passing locally, make a PR, but don't assign any
-     reviewers. Making the PR will cause the workflow tests to run, which
-     includes running `R CMD check` on several operating systems and versions of
-     R. This step takes the most time, but is important because sometimes an
-     issue will appear that didn't occur locally on your own operating system or
-     version of R.
+  3. When `R CMD check` is passing locally, build _all_ the vignettes. Because
+     of space limits imposed by CRAN, some of our vignettes are designated as
+     "web only." Such vignettes are stored in the `vignettes/web_only` directoty
+     and are not checked by `R CMD check`. They can be built manually on a
+     case-by-case basis from within R by using `tools::build_vignette`, or all
+     at once by running `pkgdown::build_site()` in an R session whose working
+     directory is set to the root directory of the BioCro repository. See the
+     ["Building package vignettes" section](#sec:building-vignettes) for more
+     information.
 
-  4. When the online checks have passed, then assign reviewers to begin the
+  4. When `R CMD check` is passing locally and the vignettes can all be built
+     locally, make a PR, but don't assign any reviewers. Making the PR will
+     cause the workflow tests to run, which includes running `R CMD check` on
+     several operating systems and versions of R, and building all the vignettes
+     as part of the package documentation. This step takes the most time, but is
+     important because sometimes an issue will appear that didn't occur locally
+     on your own operating system or version of R.
+
+  5. When the online checks have passed, then assign reviewers to begin the
      review process.
 
   Doing this will ensure that there are no basic issues when reviewers begin to

--- a/developer_documentation/running_r_cmd_check.Rmd
+++ b/developer_documentation/running_r_cmd_check.Rmd
@@ -36,10 +36,13 @@ expansive. Key components of `R CMD check` are:
   For more information about examples, see the
   [Examples section of the "R Packages" textbook][Description of examples].
 
-* It builds all of the vignettes, which are long-form pieces of documentation.
-  The vignettes can be found in the `vignettes` directory. For more information
-  about vignettes, see the
+* It builds the vignettes, which are long-form pieces of documentation that can
+  be found in the `vignettes` directory. For more information about vignettes,
+  see the
   [Vignettes section of the "R Packages" textbook][Description of vignettes].
+  Note that any vignettes inside the `vignettes/web_only` directory are excluded
+  from this check because that directory has been added to BioCro's
+  `.Rbuildignore` file.
 
 For more information about the individual checks that compose `R CMD check`,
 please see [its entry in the "R Packages" textbook][Description of R CMD check].

--- a/vignettes/building_the_vignettes.md
+++ b/vignettes/building_the_vignettes.md
@@ -1,4 +1,4 @@
-## Building package vignettes
+## Building package vignettes {#sec:build-vignettes}
 
 ### Required software
 
@@ -36,40 +36,59 @@ options:
   install.packages('devtools')
   ```
 
-### Build procedure
+### Building all vignettes at once
 
-The following instructions assume that the root of the BioCro source
-tree is a directory named `biocro`.
+The simplest (but not fastest) way to build _all_ the vignettes is to
+use the `pkgdown` package.
 
-- Build the package by running `R CMD build biocro` from the command line in
-  the directory containing `biocro`. This includes building the vignettes.
+From an R session running in the root directory of the BioCro source
+tree, type `pkgdown::build_site()`. This will build a local copy of
+the BioCro documentation web site, incuding all vignettes in the
+`vignettes/web_only` directory. (The `bookdown` book will not
+automatically be built, however.)
 
-- Then install using `R CMD INSTALL BioCro_xxx.tar.gz`, where `xxx` is the
-  version number.
+This method doesn't require that BioCro be installed. But it installs
+BioCro in a temporary location and then builds _all_ the vignettes and
+help pages, and thus it can be somewhat time consuming.
 
-- The vignettes should now be available as HTML or PDF files located
-  in `path_to_rlib/BioCro/doc`, where `path_to_rlib` is the path to
-  your R library directory.  An easy way to pull up an index to the
-  vignettes in a web browser is to run the command
-  `browseVignettes('BioCro')` in an R session.
+### Building individual vignettes
+
+From an R session running in `biocro/vignettes`, type
+`tools::buildVignette(XXX)`, where `XXX` is the name of the
+particular vignette you wish to build.  (It should have extension
+`.Rnw` or `.Rmd`.)  The resulting PDF or HTML file will appear in
+`biocro/vignettes`.
+
+This method is relatively fast and so is especially useful if you
+are writing a new vignette or revising an existing one. It also enables
+vignettes in `vignettes/web_only` to be built. If the vignette being
+built uses any BioCro code, there must be a version of BioCro installed.
 
 ### Alternative options
 
-Here are some alternative methods of building vignettes that don't
-require re-installing BioCro.
+Here are some alternative methods of building vignettes. The following
+instructions assume that the root of the BioCro source tree is a
+directory named `biocro`.
 
-- From an R session running in `biocro/vignettes`, type
-  `tools::buildVignette(XXX)`, where `XXX` is the name of the
-  particular vignette you wish to build.  (It should have extension
-  `.Rnw` or `.Rmd`.)  The resulting PDF or HTML file will appear in
-  `biocro/vignettes`.
+- Using `R CMD build`:
 
-  This method is relatively fast and so is especially useful if you
-  are writing a new vignette or revising an existing one.  If the
-  vignette being built uses any BioCro code, there must be a version
-  of BioCro installed.
+  - Build the package by running `R CMD build biocro` from the command line in
+    the directory containing `biocro`. This includes building the vignettes, but
+    will exclude any in `vignettes/web_only`, because this directory has been
+    added to BioCro's `.Rbuildignore` file.
 
-- From an R session running in any directory of the BioCro source
+  - Then install using `R CMD INSTALL BioCro_xxx.tar.gz`, where `xxx` is the
+    version number.
+
+  - The vignettes should now be available as HTML or PDF files located
+    in `path_to_rlib/BioCro/doc`, where `path_to_rlib` is the path to
+    your R library directory.  An easy way to pull up an index to the
+    vignettes in a web browser is to run the command
+    `browseVignettes('BioCro')` in an R session.
+
+- Using `devtools`:
+
+  From an R session running in any directory of the BioCro source
   tree, type `devtools::build_vignettes()`.  (Alternatively, start R
   from anywhere and pass the path to BioCro source tree as the first
   ("`pkg`") argument to `build_vignettes()`.)  This method will modify
@@ -77,9 +96,11 @@ require re-installing BioCro.
   resulting HTML and PDF files will appear in the `doc` directory,
   which will be created if it doesn't already exist.
 
-  This method doesn't require that BioCro be installed.  But it builds
-  and installs BioCro in a temporary location and then builds _all_
-  the vignettes, and thus it can be somewhat time consuming.
-  Moreover, by default it gives very little indication of build
-  progress, and so it may be useful to override this default and set
-  `quiet = FALSE` in the function argument list.
+  This method doesn't require that BioCro be installed. But it builds
+  and installs BioCro in a temporary location, and thus it can be
+  somewhat time consuming. Moreover, by default it gives very little
+  indication of build progress, and so it may be useful to override
+  this default and set `quiet = FALSE` in the function argument list.
+  Note that `devtools::build-vignettes()` follows the same procedure
+  as `R CMD build`, so it will not build any vignettes in
+  `vignettes/web_only`.


### PR DESCRIPTION
While following my own advice from PR https://github.com/biocro/biocro/pull/141, I realized that the suggested workflow was missing a step.

Because of CRAN package size requirements, we had to move most of our vignettes to `vignettes/web_only`, which is listed in `.Rbuildignore`. These vignettes are not built when running `R CMD check`, but are included when `pkgdown` builds the BioCro documentation web site.

So, even when `R CMD check` passes locally, there is still a possible surprise when the `pkgdown` site is built during the GitHub checks.

I updated some of the developer documentation to reflect this. There is now a new step in the suggested PR workflow. I also rearranged the "Building the vignettes" chapter because the main method listed (`R CMD build`) actually only builds one vignette, skipping most of them.