### PR TITLE
Update version of ubuntu used for testing

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -92,7 +92,7 @@ jobs:
           # [
           #   {
           #     "configName": "R 3.6.0 on Ubuntu",
-          #     "os": "ubuntu-20.04",
+          #     "os": "ubuntu-22.04",
           #     "r": "3.6.0"
           #   }
           # ],
@@ -101,7 +101,7 @@ jobs:
           #     [
           #       {
           #         "configName": "R 3.6.0 on Ubuntu",
-          #         "os": "ubuntu-20.04",
+          #         "os": "ubuntu-22.04",
           #         "r": "3.6.0"
           #       }
           #     ]

--- a/.github/workflows/document_quantities.yml
+++ b/.github/workflows/document_quantities.yml
@@ -48,7 +48,7 @@ jobs:
         while read -r cmd
         do
           eval sudo $cmd
-        done < <(Rscript -e 'writeLines(unlist(sapply(c("xslt", "xml2", "stringi"), function(p) { remotes::system_requirements("ubuntu", "20.04", package = p) })))')
+        done < <(Rscript -e 'writeLines(unlist(sapply(c("xslt", "xml2", "stringi"), function(p) { remotes::system_requirements("ubuntu", "22.04", package = p) })))')
 
     # Currently, this should be a no-op since BioCro doesn't have any
     # dependencies.

--- a/.github/workflows/strategy_matrix.json
+++ b/.github/workflows/strategy_matrix.json
@@ -11,17 +11,17 @@
     },
     {
         "configName": "R 3.6.0 on Ubuntu",
-        "os": "ubuntu-20.04",
+        "os": "ubuntu-22.04",
         "r": "3.6.0"
     },
     {
         "configName": "R release version on Ubuntu",
-        "os": "ubuntu-20.04",
+        "os": "ubuntu-22.04",
         "r": "release"
     },
     {
         "configName": "R devel version on Ubuntu",
-        "os": "ubuntu-20.04",
+        "os": "ubuntu-22.04",
         "r": "devel",
         "http-user-agent": "release"
     },


### PR DESCRIPTION
I got an email from GitHub about the Ubuntu-20.04 runner image closing down:

```
The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:

    March 4 14:00 UTC – 22:00 UTC
    March 11 13:00 UTC – 21:00 UTC
    March 18 13:00 UTC – 21:00 UTC
    March 25 13:00 UTC – 21:00 UTC

What you need to do

Jobs using the ubuntu-20.04 YAML workflow label should be updated to ubuntu-22.04, ubuntu-24.04 or ubuntu-latest.
```

In this PR, I have changed all instances of ubuntu-20.04 to ubuntu-22.04. This seemed like the smallest change to our current setup. I could also try ubuntu-24.04 or ubuntu-latest if people think that might be better.