### PR TITLE
Alternate secant method code

### DIFF
--- a/src/module_library/c3photo.cpp
+++ b/src/module_library/c3photo.cpp
@@ -139,15 +139,23 @@ photosynthesis_outputs c3photoC(
         Ca * gbw / dr_boundary                 // The maximum conductance-limited An, which occurs for gsw = infinity
     });                                        // micromol / m^2 / s
 
-    secant_parameters secpar{1000, 1e-12, 1e-12};
+    // Run the secant method
+    double Assim_check{};  // Will be modified by find_root_secant_method
+    size_t iterations;     // Will be modified by find_root_secant_method
 
-    // find_root_secant_method will update secpar as a side-effect
     double const co2_assim_rate = find_root_secant_method(
-        check_assim_rate, assim_guess_0, assim_guess_1, secpar);
+        check_assim_rate,
+        assim_guess_0,
+        assim_guess_1,
+        1000,
+        1e-12,
+        1e-12,
+        Assim_check,
+        iterations);
 
     return photosynthesis_outputs{
         /* .Assim = */ co2_assim_rate,              // micromol / m^2 / s
-        /* .Assim_check = */ secpar.check,          // micromol / m^2 / s
+        /* .Assim_check = */ Assim_check,           // micromol / m^2 / s
         /* .Assim_conductance = */ an_conductance,  // micromol / m^2 / s
         /* .Ci = */ Ci,                             // micromol / mol
         /* .Cs = */ BB_res.cs,                      // micromol / m^2 / s
@@ -155,7 +163,7 @@ photosynthesis_outputs c3photoC(
         /* .Gs = */ Gs,                             // mol / m^2 / s
         /* .RHs = */ BB_res.hs,                     // dimensionless from Pa / Pa
         /* .Rp = */ FvCB_res.Vc * Gstar / Ci,       // micromol / m^2 / s
-        /* .iterations = */ secpar.counter          // not a physical quantity
+        /* .iterations = */ iterations              // not a physical quantity
     };
 }
 

--- a/src/module_library/c4photo.cpp
+++ b/src/module_library/c4photo.cpp
@@ -125,18 +125,26 @@ photosynthesis_outputs c4photoC(
     double const assim_guess_0 = collatz_assim(0.4 * Ca_pa);
     double const assim_guess_1 = collatz_assim(Ca_pa);
 
-    secant_parameters secpar{1000, 1e-12, 1e-12};
+    // Run the secant method
+    double Assim_check{};  // Will be modified by find_root_secant_method
+    size_t iterations;     // Will be modified by find_root_secant_method
 
-    // find_root_secant_method will update secpar as a side-effect
     double const Assim = find_root_secant_method(
-        check_assim_rate, assim_guess_0, assim_guess_1, secpar);
+        check_assim_rate,
+        assim_guess_0,
+        assim_guess_1,
+        1000,
+        1e-12,
+        1e-12,
+        Assim_check,
+        iterations);
 
-    // unit change
-    double const Ci = Ci_pa / atmospheric_pressure * 1e6;  // micromole / mol
+    // Convert Ci units
+    double const Ci = Ci_pa / atmospheric_pressure * 1e6;  // micromol / mol
 
     return photosynthesis_outputs{
         /* .Assim = */ Assim,                       // micromol / m^2 /s
-        /* .Assim_cehck = */ secpar.check,          // micromol / m^2 / s
+        /* .Assim_check = */ Assim_check,           // micromol / m^2 / s
         /* .Assim_conductance = */ an_conductance,  // micromol / m^2 / s
         /* .Ci = */ Ci,                             // micromol / mol
         /* .Cs = */ BB_res.cs,                      // micromol / m^2 / s
@@ -144,6 +152,6 @@ photosynthesis_outputs c4photoC(
         /* .Gs = */ Gs,                             // mol / m^2 / s
         /* .RHs = */ BB_res.hs,                     // dimensionless from Pa / Pa
         /* .Rp = */ 0,                              // micromol / m^2 / s
-        /* .iterations = */ secpar.counter          // not a physical quantity
+        /* .iterations = */ iterations              // not a physical quantity
     };
 }

--- a/src/module_library/photosynthesis_outputs.h
+++ b/src/module_library/photosynthesis_outputs.h
@@ -15,7 +15,7 @@ struct photosynthesis_outputs {
     double Gs;                 //!< Stomatal conductance to water vapor (mol / m^2 / s)
     double RHs;                //!< Relative humidity at the leaf surface (dimensionless)
     double Rp;                 //!< Rate of photorespiration (micromol / m^2 / s)
-    int iterations;            //!< Number of iterations used by convergence loop
+    size_t iterations;         //!< Number of iterations used by convergence loop
 };
 
 #endif

--- a/src/module_library/secant_method.h
+++ b/src/module_library/secant_method.h
@@ -7,34 +7,6 @@
 // Helper function declarations
 inline bool is_close(double x, double y, double atol, double rtol);
 inline bool is_zero(double x, double atol);
-/**
- * @struct A struct to hold parameters related to the secant method.
- *
- * @param check The value of the function at its last evaluation. If a
- *              root has been found, this should equal zero to within
- *              tolerance.
- * @param counter The number of iterations completed at termination of the secant
- *              method. Zero indicates no iterations. A value of 10
- *              indicates 10 iterations were completed.
- * @param max_iter The total number of iterations allowed. The secant method
- *              will terminate when this number is reached.
- * @param atol The absolute tolerance used to test for floating point number
- *              equality; primarily used to test if a zero has been found:
- *              Terminate if `abs(check) < atol`
- * @param rtol The relative tolerance used to test if iterates are not
- *              improving: Terminate if `abs(x0 - x1) <= atol + rtol * abs(x1)`
- */
-struct secant_parameters {
-    double check = 0;
-    int counter = 0;
-    const size_t max_iter = 100;
-    const double atol = 1e-12;
-    const double rtol = 1e-12;
-
-    secant_parameters(){};
-    secant_parameters(size_t max_iter, double atol, double rtol)
-        : check{0}, counter{0}, max_iter{max_iter}, atol{atol}, rtol{rtol} {};
-};
 
 /**
  * @brief Finds the zero of a function using the secant method.
@@ -83,76 +55,97 @@ struct secant_parameters {
  * The order of initial guesses can affect convergence, so make the second guess
  * the closer of the two if possible.
  *
- * @param [in] fun A function or object with `double operator()(double)` signature
- *             This routine is templated so any type with a call operator with
- *              the correct type signature will work.
- * @param [in] x0 The first guess.
- * @param [in] x1 The second guess.
- *             type signature secant method calls this.
- * @param [in] par The parameters for tolerances, maximum number of iterations, etc.
- *              See the `secant_parameters` documentation. These are passed by
- *             reference so the secant method routine can save the final function
- *              evaluation (as a check on accuracy) and the number of iterations.
+ * @param [in] fun A function or object with `double operator()(double)`
+ *             signature. This routine is templated so any type with a call
+ *             operator with the correct type signature will work.
  *
- * @return Approximate root. If the method fails, it will return it's last (and
- *      presumably best) guess for the root. If `check` member field in the
- *      secant_parameters object is not zero, then the method has failed.
- *      This routine will terminate if NaN or non-finite guesses are encountered.
+ * @param [in] x0 The first guess.
+ *
+ * @param [in] x1 The second guess.
+ *
+ * @param [in] max_iter The total number of iterations allowed. The secant
+ *             method will terminate when this number is reached.
+ *
+ * @param [in] atol The absolute tolerance used to test for floating point
+ *             number equality; primarily used to test if a zero has been found:
+ *             Terminate if `abs(check) < atol`
+ *
+ * @param [in] rtol The relative tolerance used to test if iterates are not
+ *             improving: Terminate if `abs(x0 - x1) <= atol + rtol * abs(x1)`
+ *
+ * @param [out] check The value of the function at its last evaluation. If a
+ *              root has been found, this should equal zero to within the
+ *              absolute tolerance.
+ *
+ * @param [out] counter The number of iterations completed at termination of the
+ *              secant method. For example, a value of zero indicates that no
+ *              iterations were needed, while a value of 10 indicates 10
+ *              iterations were completed.
+ *
+ * @return Approximate root. If the method fails, it will return its last (and
+ *         presumably best) guess for the root. If `check` is not zero, then the
+ *         method has failed. This routine will terminate if NaN or non-finite
+ *         guesses are encountered.
  */
 template <typename F>
 double find_root_secant_method(
-    F fun, double x0, double x1, secant_parameters& par)
+    F const fun,
+    double x0,
+    double x1,
+    size_t const max_iter,
+    double const atol,
+    double const rtol,
+    double& check,
+    size_t& counter)
 {
     // Check inputs for trivial solutions
     double y0 = fun(x0);
-    if (is_zero(y0, par.atol)) {
-        par.counter = 0;
-        par.check = y0;
+    if (is_zero(y0, atol)) {
+        counter = 0;
+        check = y0;
         return x0;
     }
 
     // Guesses should be different
-    if (is_close(x1, x0, par.atol, par.rtol)) {
+    if (is_close(x1, x0, atol, rtol)) {
         throw std::runtime_error(
-            "Within tolerance, x0 == x1. Initial guesses should be distinct. ");
+            "Within tolerance, x0 == x1. Initial guesses should be distinct.");
     }
 
     // Check second solution
     double y1 = fun(x1);
-    if (is_zero(y1, par.atol)) {
-        par.counter = 0;
-        par.check = y1;
+    if (is_zero(y1, atol)) {
+        counter = 0;
+        check = y1;
         return x1;
     }
 
-    for (size_t n = 1; n <= par.max_iter; ++n) {
+    for (size_t n = 1; n <= max_iter; ++n) {
         double secant_slope = (y1 - y0) / (x1 - x0);
 
-        // Secant Update Formula
+        // Secant update formula
         double x2 = x1 - y1 / secant_slope;
 
-        // Stop if divide by generates non finite value
-        // Shouldn't occur, except when y1 == y0 but x1 != x0
+        // Stop if the secant formula generates a non-finite value. This should
+        // not occur, except when y1 == y0 but x1 != x0.
         if (not std::isfinite(x2)) {
-            par.counter = n;
-            par.check = y1;
+            counter = n;
+            check = y1;
             return x1;
         }
 
         double y2 = fun(x2);
 
-        // Test convergence
-        // If y2 == 0, then x2 is a root
-        if (is_zero(y2, par.atol)) {
-            par.counter = n;
-            par.check = y2;
+        // Test convergence; if y2 == 0, then x2 is a root.
+        if (is_zero(y2, atol)) {
+            counter = n;
+            check = y2;
             return x2;
         }
-        // If no improvement in guesses, then terminate
-        // Prevents x1 == x0
-        if (is_close(x1, x2, par.atol, par.rtol)) {
-            par.counter = n;
-            par.check = y2;
+        // If no improvement in guesses, then terminate; prevents x1 == x0.
+        if (is_close(x1, x2, atol, rtol)) {
+            counter = n;
+            check = y2;
             return x2;
         }
 
@@ -163,8 +156,8 @@ double find_root_secant_method(
         y1 = y2;
     }
 
-    par.counter = par.max_iter;
-    par.check = y1;
+    counter = max_iter;
+    check = y1;
     return x1;
 }
 


### PR DESCRIPTION
I also found it a bit confusing that the `secant_parameters` struct included inputs and outputs. Here's one approach to addressing this, where I just added more arguments to `find_root_secant_method`, following a suggestion from Justin.

Another possibility could be to use a `struct` for returning the final value of `x`, the check, and the counter.