### PR TITLE
Take different approach to formatting

### DIFF
--- a/R/module_testing.R
+++ b/R/module_testing.R
@@ -1,4 +1,4 @@
-test_module <- function(module_name, case_to_test) {
+test_module <- function(module_name, case_to_test, verbose = TRUE) {
     # Get the expected outputs
     expected_outputs <- case_to_test[["expected_outputs"]]
 
@@ -30,29 +30,66 @@ test_module <- function(module_name, case_to_test) {
 
     # Check to see if the expected and actual outputs match
     if (!isTRUE(all.equal(expected_outputs, actual_outputs))) {
-        which_not_equal <- function(x, y) {
-            abs(x - y) > sqrt(.Machine$double.eps)
+        # Collect discrepancies into a table and print it to the terminal, if
+        # desired
+        if (verbose) {
+            idx <- sapply(seq_along(expected_outputs), function(i) {
+                qname <- names(expected_outputs)[[i]]
+                expected <- expected_outputs[[i]]
+
+                actual <- if (qname %in% names(actual_outputs)) {
+                    actual_outputs[[qname]]
+                } else {
+                    NA
+                }
+
+                if (is.na(actual)) {
+                    TRUE
+                } else {
+                    abs(expected - actual) > sqrt(.Machine$double.eps)
+                }
+            })
+
+            qnames <- names(expected_outputs)[idx]
+            expected <- unlist(expected_outputs)[idx]
+
+            actual <- sapply(qnames, function(qn) {
+                if (qn %in% names(actual_outputs)) {
+                    actual_outputs[[qn]]
+                } else {
+                    NA
+                }
+            })
+
+            differences <- data.frame(
+                Quantity = qnames,
+                Expected = expected,
+                Actual = actual,
+                stringsAsFactors = FALSE
+            )
+
+            rownames(differences) <- NULL
+
+            cat(paste0(
+                '\nDifferences found for Module `',
+                module_name,
+                '` test case `',
+                case_to_test[['description']],
+                '`:\n\n'
+            ))
+
+            print(differences)
+
+            cat('\n')
         }
-        idx <- which_not_equal(
-            unlist(expected_outputs),
-            unlist(actual_outputs)
-        )
-        es <- expected_outputs[idx]
-        acs <- actual_outputs[idx]
-        out <- paste(
-            names(es), es, acs,
-            sep = "\t"
-        )
-        header <- paste("", "Expected", "Actual\t\n", sep = "\t")
+
         return(
             paste0(
                 "Module `",
                 module_name,
                 "` test case `",
                 case_to_test[["description"]],
-                "`: calculated outputs do not match expected outputs\t\n",
-                header,
-                out
+                "`: calculated outputs do not match expected outputs"
             )
         )
     } else {
@@ -355,7 +392,8 @@ module_names_from_case_directory <- function(library_name, directory) {
 test_module_library <- function(
     library_name,
     directory,
-    modules_to_skip = c()) {
+    modules_to_skip = c(),
+    verbose = TRUE) {
     # Get the module names associated with the test cases in the directory
     directory_module_names <-
         module_names_from_case_directory(library_name, directory)
@@ -419,7 +457,7 @@ test_module_library <- function(
 
         # Run each test case
         lapply(cases, function(case) {
-            test_module(module, case)
+            test_module(module, case, verbose)
         })
     })
 

--- a/man/test_module.Rd
+++ b/man/test_module.Rd
@@ -27,7 +27,7 @@
 }
 
 \usage{
-  test_module(module_name, case_to_test)
+  test_module(module_name, case_to_test, verbose = TRUE)
 
   case(inputs, expected_outputs, description)
 
@@ -57,6 +57,12 @@
             \code{"temp below tbase"}. The description should be succinct and
             not contain any newline characters.
     }
+  }
+
+  \item{verbose}{
+    A logical value indicating whether to print information about failed tests
+    to the R terminal. When \code{verbose} is \code{TRUE}, any module outputs
+    that do not match the expected value will be printed.
   }
 
   \item{inputs}{
@@ -127,7 +133,8 @@ test_module(
 
 # Example 2: Defining an individual test case for the 'BioCro' module library's
 # 'thermal_time_linear' module and running the test. This test will fail, so the
-# return value will be a message indicating the failure.
+# return value will be a message indicating the failure. Because verbose is TRUE
+# by default, information about the failure will also be printed.
 test_module(
   'BioCro:thermal_time_linear',
   case(

--- a/man/test_module_library.Rd
+++ b/man/test_module_library.Rd
@@ -15,7 +15,12 @@
 }
 
 \usage{
-  test_module_library(library_name, directory, modules_to_skip = c())
+  test_module_library(
+    library_name,
+    directory,
+    modules_to_skip = c(),
+    verbose = TRUE
+  )
 }
 
 \arguments{
@@ -30,6 +35,10 @@
     A vector of local module name strings indicating any modules from the
     library that should not be tested. This feature should be used sparingly,
     since there are very few legitimate reasons to skip a module test.
+  }
+
+  \item{verbose}{
+    To be passed to \code{\link{test_module}}.
   }
 }
 


### PR DESCRIPTION
This PR takes a different approach to formatting the error messages when there is an issue with a module test case. These error messages are also optional now, so users can turn them off if they don't want to see them. (Although, who would want to do this?)

You can see how it works by changing an input or output in one of the saved test case files.