### PR TITLE
Fix vignette math

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <!-- badges: start -->
 [![CRAN status](https://www.r-pkg.org/badges/version/BioCro)](https://CRAN.R-project.org/package=BioCro)
+[![](https://cranlogs.r-pkg.org/badges/grand-total/BioCro)](https://CRAN.R-project.org/package=BioCro)
 [![Build Status](https://github.com/biocro/biocro/workflows/R-CMD-check/badge.svg)](https://github.com/biocro/biocro/actions?query=workflow%3AR-CMD-check)
 <!-- badges: end -->
 

--- a/vignettes/web_only/avoiding_pitfalls_fvcb.Rmd
+++ b/vignettes/web_only/avoiding_pitfalls_fvcb.Rmd
@@ -5,6 +5,7 @@ output:
     toc: true
     number_sections: true
     fig_caption: yes
+    math_method: mathml
 vignette: >
   %\VignetteIndexEntry{Avoiding Pitfalls When Using the FvCB Model}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/web_only/ball_berry_model.Rmd
+++ b/vignettes/web_only/ball_berry_model.Rmd
@@ -5,6 +5,7 @@ output:
     toc: true
     number_sections: true
     fig_caption: yes
+    math_method: mathml
 vignette: >
   %\VignetteIndexEntry{Using the Ball-Berry Model in Crop Growth Simulations}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/web_only/canopy_photosynthesis.Rmd
+++ b/vignettes/web_only/canopy_photosynthesis.Rmd
@@ -5,6 +5,7 @@ output:
     toc: true
     number_sections: true
     fig_caption: yes
+    math_method: mathml
 vignette: >
   %\VignetteIndexEntry{Canopy Photosynthesis Models}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/web_only/energy_balance.Rmd
+++ b/vignettes/web_only/energy_balance.Rmd
@@ -5,6 +5,7 @@ output:
     toc: true
     number_sections: true
     fig_caption: yes
+    math_method: mathml
 vignette: >
   %\VignetteIndexEntry{Energy Balance, Transpiration, and Leaf Temperature}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/web_only/thick_layer_absorption.Rmd
+++ b/vignettes/web_only/thick_layer_absorption.Rmd
@@ -5,6 +5,7 @@ output:
   bookdown::html_vignette2:
     toc: true
     number_sections: true
+    math_method: mathml
 vignette: >
   %\VignetteIndexEntry{Light Absorption by a Thick Layer}
   %\VignetteEngine{knitr::rmarkdown}


### PR DESCRIPTION
Recently I noticed that the math formatting in some of our vignettes was not right. See, for example, this one: https://biocro.github.io/BioCro-documentation/latest/pkgdown/articles/web_only/canopy_photosynthesis.html

You can see a bunch of stuff like `\(Q_{in}\)` instead of $Q_{in}$.

It turns out this was caused by a change in the `pkgdown` package, as described here: https://github.com/r-lib/pkgdown/issues/2739

The fix is simple -- I just had to add a new line to the top of each HTML vignette.

I also added a badge to the README that shows how many times BioCro has been downloaded from CRAN.