### PR TITLE
fix negative RH_canopy calculation

### DIFF
--- a/src/module_library/leaf_energy_balance.cpp
+++ b/src/module_library/leaf_energy_balance.cpp
@@ -188,7 +188,7 @@ energy_balance_outputs leaf_energy_balance(
     double const storage = Phi_N - H - lambda * E;              // J / m^2 / s
 
     // Relative humidity just outside the leaf boundary layer
-    double const RH_canopy = (rho_w_air - E / gbw_canopy) / rho_w_sat;  // dimensionless
+    double const RH_canopy = (rho_w_air + E / gbw_canopy) / rho_w_sat;  // dimensionless
 
     // Potential evapotranspiration can be calculated assuming infinite stomatal
     // conductance; here we call this "Penman transpiration."


### PR DESCRIPTION
This PR makes a simple change to the calculation of the [RH_canopy](https://github.com/biocro/biocro/blob/b8ed26816d127296c4642590949882c8e6bf8af5/src/module_library/leaf_energy_balance.cpp#L191). Ed will also add tests for negative RH to this PR.

Without doing this, we can get negative `RH_canopy`. This is because given the incorrect equation:

`RH_canopy = (rho_w_air - E / gbw_canopy) / rho_w_sat`

Re-arranging the equation to solve for transpiration `E` we get: 

`E= gbw_canopy * (rho_w_air - rho_w_leaf)`

Where `rho_w_leaf = rho_w_sat * RH_canopy`. 

When` E>0, rho_w_air > rho_w_leaf`. This suggests that the water vapor flows from the air into the leaf, which counters the concept of `E > 0`. The [energy balance vignettes](https://github.com/biocro/biocro/blob/b8ed26816d127296c4642590949882c8e6bf8af5/vignettes/web_only/energy_balance.Rmd#L103) shows the correct equation. From it you can also see that the sign should be `+` when solving for `rho_w_leaf`.

However, this change can cause `RH_canopy > 1` in rare occasions, mostly when `gbw_canopy` is close to its minimum. Physically, this means the near-canopy surface is super-saturated. Ed suggests this might be due to other issues related to, for example, the `gbw_canopy` calculation, which should be addressed further in a different PR.

The following code can be used to investigate `RH_canopy` (courtesy of Ed).
```
library(BioCro)
library(lattice)
res <- with(soybean, {run_biocro(
  initial_values,
  parameters,
  soybean_weather[['2004']],
  direct_modules,
  differential_modules,
  ode_solver
)})
res <- within(res, {
  sunlit_delta_T_layer_0 = sunlit_leaf_temperature_layer_0 - temp
})
xyplot(
  sunlit_RH_canopy_layer_0 ~ gbw_canopy,
  group = sunlit_RH_canopy_layer_0 > 1,
  data = res,
  type = 'p',
  pch = 16, 
  auto = TRUE
)
```