### PR TITLE
Fix vignettes again

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -1,4 +1,5 @@
 template:
+  math-rendering: mathjax
   bootstrap: 5
   bootswatch: flatly
   theme: arrow-light

--- a/vignettes/web_only/BioCro-II_Paper--Section-1.1-example.Rmd
+++ b/vignettes/web_only/BioCro-II_Paper--Section-1.1-example.Rmd
@@ -16,7 +16,6 @@ bibliography: references/BioCro.bibtex
 knitr::opts_chunk$set(
   error = FALSE,
   collapse = TRUE,
-  cache = TRUE,
   autodep = TRUE
 )
 ```

--- a/vignettes/web_only/avoiding_pitfalls_fvcb.Rmd
+++ b/vignettes/web_only/avoiding_pitfalls_fvcb.Rmd
@@ -5,7 +5,6 @@ output:
     toc: true
     number_sections: true
     fig_caption: yes
-    math_method: mathml
 vignette: >
   %\VignetteIndexEntry{Avoiding Pitfalls When Using the FvCB Model}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/web_only/ball_berry_model.Rmd
+++ b/vignettes/web_only/ball_berry_model.Rmd
@@ -5,7 +5,6 @@ output:
     toc: true
     number_sections: true
     fig_caption: yes
-    math_method: mathml
 vignette: >
   %\VignetteIndexEntry{Using the Ball-Berry Model in Crop Growth Simulations}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/web_only/canopy_photosynthesis.Rmd
+++ b/vignettes/web_only/canopy_photosynthesis.Rmd
@@ -5,7 +5,6 @@ output:
     toc: true
     number_sections: true
     fig_caption: yes
-    math_method: mathml
 vignette: >
   %\VignetteIndexEntry{Canopy Photosynthesis Models}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/web_only/energy_balance.Rmd
+++ b/vignettes/web_only/energy_balance.Rmd
@@ -5,7 +5,6 @@ output:
     toc: true
     number_sections: true
     fig_caption: yes
-    math_method: mathml
 vignette: >
   %\VignetteIndexEntry{Energy Balance, Transpiration, and Leaf Temperature}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/web_only/thick_layer_absorption.Rmd
+++ b/vignettes/web_only/thick_layer_absorption.Rmd
@@ -5,7 +5,6 @@ output:
   bookdown::html_vignette2:
     toc: true
     number_sections: true
-    math_method: mathml
 vignette: >
   %\VignetteIndexEntry{Light Absorption by a Thick Layer}
   %\VignetteEngine{knitr::rmarkdown}


### PR DESCRIPTION
A recent version of `pkgdown` changed the default math rendering engine from mathjax to something else, and it messed up several of our vignettes. I thought I had fixed the issue in PR #187, but it seems I did not. I swear I tested the vignettes and the `pkgdown` site, but now a different problem has popped up, where the equation references are not working correctly.

This PR reverts the math rendering back to mathjax, and it seems to work -- I tried building the vignettes using `tools::buildVignette` and `pkgdown::build_site`, and they seemed to be formatted properly, and the references are working.