### PR TITLE
Code for solving multidimensional nonlinear equations: Broyden's good method

### DIFF
--- a/src/module_library/broyden_method.h
+++ b/src/module_library/broyden_method.h
@@ -45,7 +45,7 @@ struct broyden {
     }
 
    private:
-    void set_identity(mat_t& A)
+    void inline set_identity(mat_t& A)
     {
         for (size_t i = 0; i < dim; ++i) {
             for (size_t j = 0; j < dim; ++j) {
@@ -56,7 +56,7 @@ struct broyden {
         }
     }
 
-    void update_delta_x(
+    void inline update_delta_x(
         vec_t& delta_x, const vec_t& y, const mat_t& inv_jac)
     {
         // delta_x = - inv_jac * y
@@ -68,7 +68,7 @@ struct broyden {
         }
     }
 
-    void update_x(
+    void inline update_x(
         vec_t& x, const vec_t& delta_x)
     {
         // x += delta_x
@@ -77,7 +77,7 @@ struct broyden {
         }
     }
 
-    void update_delta_y(vec_t& delta_y, vec_t& y)
+    void inline update_delta_y(vec_t& delta_y, vec_t& y)
     {
         for (size_t i = 0; i < dim; ++i) {
             std::swap(delta_y[i], y[i]);
@@ -85,7 +85,7 @@ struct broyden {
         }
     }
 
-    void update_inv_jac(mat_t& inv_jac, const vec_t& delta_y, const vec_t& delta_x)
+    void inline update_inv_jac(mat_t& inv_jac, const vec_t& delta_y, const vec_t& delta_x)
     {
         // out = inv_jac + (delta_x - inv_jac * delta_y) / ( t(delta_x) * inv_jac * delta_y ) * t(delta_x) * inv_jac
         vec_t a;
@@ -108,7 +108,7 @@ struct broyden {
         }
     }
 
-    bool is_zero(const vec_t& y)
+    bool inline is_zero(const vec_t& y)
     {
         T sq = 0;
         for (size_t i = 0; i < dim; ++i) {

--- a/src/module_library/broyden_method.h
+++ b/src/module_library/broyden_method.h
@@ -1,0 +1,19 @@
+#ifndef BROYDEN_METHOD_H
+#define BROYDEN_METHOD_H
+
+#include "root_onedim.h"
+#include <array>
+
+template <typename T, size_t dim>
+struct broyden {
+    using vec_t = typename std::array<T, dim>;
+
+    struct result_t {
+        vec_t zero;
+        vec_t residual;
+        size_t iteration;
+        root_algorithm::Flag flag;
+    };
+};
+
+#endif

--- a/src/module_library/broyden_method.h
+++ b/src/module_library/broyden_method.h
@@ -14,6 +14,11 @@ struct broyden {
         size_t iteration;
         root_algorithm::Flag flag;
     };
+
+    template <typename F>
+    result_t solve(F&& fun, vec_t x0)
+    {
+    }
 };
 
 #endif

--- a/src/module_library/broyden_method.h
+++ b/src/module_library/broyden_method.h
@@ -1,23 +1,120 @@
 #ifndef BROYDEN_METHOD_H
 #define BROYDEN_METHOD_H
 
-#include "root_onedim.h"
+// #include "root_onedim.h"
 #include <array>
+#include <cmath>
+#include <functional>
 
 template <typename T, size_t dim>
 struct broyden {
     using vec_t = typename std::array<T, dim>;
+    using mat_t = typename std::array<std::array<T, dim>, dim>;
 
     struct result_t {
         vec_t zero;
         vec_t residual;
         size_t iteration;
-        root_algorithm::Flag flag;
     };
 
+    size_t max_iterations;
+    double _abs_tol;
+    double _rel_tol;
+
     template <typename F>
-    result_t solve(F&& fun, vec_t x0)
+    result_t solve(F&& fun, vec_t x)
     {
+        vec_t y;
+        mat_t inv_jac;
+        fun(y, x);
+        set_identity(inv_jac);
+        vec_t delta_x;
+        vec_t delta_y;
+
+        for (size_t i = 0; i <= max_iterations; ++i) {
+            update_delta_x(delta_x, y, inv_jac);
+            update_x(x, delta_x);
+            fun(delta_y, x);
+            update_delta_y(delta_y, y);
+            if (is_zero(y)) {
+                return result_t{x, y, i};
+            }
+            update_inv_jac(inv_jac, delta_y, delta_x);
+        }
+        return result_t{x, y, max_iterations};
+    }
+
+   private:
+    void set_identity(mat_t& A)
+    {
+        for (size_t i = 0; i < dim; ++i) {
+            for (size_t j = 0; j < dim; ++j) {
+                A[i][j] = 0;
+                if (i == j)
+                    A[i][j] = 1;
+            }
+        }
+    }
+
+    void update_delta_x(
+        vec_t& delta_x, const vec_t& y, const mat_t& inv_jac)
+    {
+        // delta_x = - inv_jac * y
+        for (size_t i = 0; i < dim; ++i) {
+            delta_x[i] = -inv_jac[i][0] * y[0];
+            for (size_t j = 1; j < dim; ++j) {
+                delta_x[i] -= inv_jac[i][j] * y[j];
+            }
+        }
+    }
+
+    void update_x(
+        vec_t& x, const vec_t& delta_x)
+    {
+        // x += delta_x
+        for (size_t i = 0; i < dim; ++i) {
+            x[i] += delta_x[i];
+        }
+    }
+
+    void update_delta_y(vec_t& delta_y, vec_t& y)
+    {
+        for (size_t i = 0; i < dim; ++i) {
+            std::swap(delta_y[i], y[i]);
+            delta_y[i] = y[i] - delta_y[i];
+        }
+    }
+
+    void update_inv_jac(mat_t& inv_jac, const vec_t& delta_y, const vec_t& delta_x)
+    {
+        // out = inv_jac + (delta_x - inv_jac * delta_y) / ( t(delta_x) * inv_jac * delta_y ) * t(delta_x) * inv_jac
+        vec_t a;
+        vec_t b;
+        b.fill(0);
+        T c = 0;
+        for (size_t i = 0; i < dim; ++i) {
+            a[i] = delta_x[i];
+            for (size_t j = 0; j < dim; ++j) {
+                a[i] -= inv_jac[i][j] * delta_y[j];
+                b[j] += delta_x[i] * inv_jac[i][j];
+                c += delta_x[i] * inv_jac[i][j] * delta_y[j];
+            }
+        }
+
+        for (size_t i = 0; i < dim; ++i) {
+            for (size_t j = 0; j < dim; ++j) {
+                inv_jac[i][j] += a[i] * b[j] / c;
+            }
+        }
+    }
+
+    bool is_zero(const vec_t& y)
+    {
+        T sq = 0;
+        for (size_t i = 0; i < dim; ++i) {
+            sq += y[i] * y[i];
+        }
+        return std::sqrt(sq) < _abs_tol;
     }
 };
 

--- a/src/module_library/broyden_test.h
+++ b/src/module_library/broyden_test.h
@@ -43,27 +43,11 @@ class broyden_test : public direct_module
         : direct_module{},
 
           // Get pointers to input quantities
-          ecc{get_input(input_quantities, "ecc")},
-          answer{get_input(input_quantities, "answer")},
           max_iterations{get_input(input_quantities, "max_iterations")},
           abs_tol{get_input(input_quantities, "abs_tol")},
           rel_tol{get_input(input_quantities, "rel_tol")},
-          lower_bracket{get_input(input_quantities, "lower_bracket")},
-          upper_bracket{get_input(input_quantities, "upper_bracket")},
-          single_guess{get_input(input_quantities, "single_guess")},
 
-          // Get pointers to output quantities
-          secant_result{output_quantities, "secant"},
-          fixed_point_result{output_quantities, "fixed_point"},
-          newton_result{output_quantities, "newton"},
-          halley_result{output_quantities, "halley"},
-          steffensen_result{output_quantities, "steffensen"},
-          bisection_result{output_quantities, "bisection"},
-          regula_falsi_result{output_quantities, "regula_falsi"},
-          ridder_result{output_quantities, "ridder"},
-          illinois_result{output_quantities, "illinois"},
-          pegasus_result{output_quantities, "pegasus"},
-          anderson_bjorck_result{output_quantities, "anderson_bjorck"}
+    // Get pointers to output quantities
 
     {
     }
@@ -73,27 +57,11 @@ class broyden_test : public direct_module
 
    private:
     // Pointers to input quantities
-    const double& ecc;
-    const double& answer;
     const double& max_iterations;
     const double& abs_tol;
     const double& rel_tol;
-    const double& lower_bracket;
-    const double& upper_bracket;
-    const double& single_guess;
 
     // Pointers to output quantities
-    result secant_result;
-    result fixed_point_result;
-    result newton_result;
-    result halley_result;
-    result steffensen_result;
-    result bisection_result;
-    result regula_falsi_result;
-    result ridder_result;
-    result illinois_result;
-    result pegasus_result;
-    result anderson_bjorck_result;
 
     // Main operation
     void do_operation() const;

--- a/src/module_library/broyden_test.h
+++ b/src/module_library/broyden_test.h
@@ -1,0 +1,153 @@
+#ifndef BROYDEN_TEST_H
+#define BROYDEN_TEST_H
+
+#include "../framework/module.h"
+#include "../framework/state_map.h"
+#include "broyden_method.h"
+
+#include <array>
+
+namespace standardBML
+{
+
+std::array<double, 2> test_function(std::array<double, 2> x)
+{
+    std::array<double, 2> y;
+    y[0] = x[0] / (x[0] * x[0] + 1) - x[1] + 0.5;
+    y[1] = 2 - x[0] - x[1];
+    return y;
+}
+
+class broyden_test : public direct_module
+{
+    struct result {
+        double* root_op;
+        double* residual_op;
+        double* iteration_op;
+        double* flag_op;
+
+        result(
+            state_map* output_quantities,
+            std::string&& name)
+            : root_op{get_op(output_quantities, name + "_root")},
+              residual_op{get_op(output_quantities, name + "_residual")},
+              iteration_op{get_op(output_quantities, name + "_iteration")},
+              flag_op{get_op(output_quantities, name + "_flag")}
+        {
+        }
+    };
+
+   public:
+    broyden_test(
+        state_map const& input_quantities, state_map* output_quantities)
+        : direct_module{},
+
+          // Get pointers to input quantities
+          ecc{get_input(input_quantities, "ecc")},
+          answer{get_input(input_quantities, "answer")},
+          max_iterations{get_input(input_quantities, "max_iterations")},
+          abs_tol{get_input(input_quantities, "abs_tol")},
+          rel_tol{get_input(input_quantities, "rel_tol")},
+          lower_bracket{get_input(input_quantities, "lower_bracket")},
+          upper_bracket{get_input(input_quantities, "upper_bracket")},
+          single_guess{get_input(input_quantities, "single_guess")},
+
+          // Get pointers to output quantities
+          secant_result{output_quantities, "secant"},
+          fixed_point_result{output_quantities, "fixed_point"},
+          newton_result{output_quantities, "newton"},
+          halley_result{output_quantities, "halley"},
+          steffensen_result{output_quantities, "steffensen"},
+          bisection_result{output_quantities, "bisection"},
+          regula_falsi_result{output_quantities, "regula_falsi"},
+          ridder_result{output_quantities, "ridder"},
+          illinois_result{output_quantities, "illinois"},
+          pegasus_result{output_quantities, "pegasus"},
+          anderson_bjorck_result{output_quantities, "anderson_bjorck"}
+
+    {
+    }
+    static string_vector get_inputs();
+    static string_vector get_outputs();
+    static std::string get_name() { return "broyden_test"; }
+
+   private:
+    // Pointers to input quantities
+    const double& ecc;
+    const double& answer;
+    const double& max_iterations;
+    const double& abs_tol;
+    const double& rel_tol;
+    const double& lower_bracket;
+    const double& upper_bracket;
+    const double& single_guess;
+
+    // Pointers to output quantities
+    result secant_result;
+    result fixed_point_result;
+    result newton_result;
+    result halley_result;
+    result steffensen_result;
+    result bisection_result;
+    result regula_falsi_result;
+    result ridder_result;
+    result illinois_result;
+    result pegasus_result;
+    result anderson_bjorck_result;
+
+    // Main operation
+    void do_operation() const;
+
+    static string_vector make_qname(std::string& name)
+    {
+        return {
+            name + "_root",
+            name + "_residual",
+            name + "_iteration",
+            name + "_flag"};
+    }
+
+    void inline update_result(
+        const result& r, root_algorithm::result_t& result) const
+    {
+        update(r.root_op, result.root);
+        update(r.residual_op, result.residual);
+        update(r.iteration_op, result.iteration);
+        update(r.flag_op, static_cast<int>(result.flag));
+    }
+};
+
+string_vector broyden_test::get_inputs()
+{
+    return {
+        "ecc",
+        "answer",
+        "max_iterations",
+        "abs_tol",
+        "rel_tol",
+        "lower_bracket",
+        "upper_bracket",
+        "single_guess"};
+}
+
+string_vector broyden_test::get_outputs()
+{
+    string_vector out;
+    const string_vector methods = {
+        "secant", "fixed_point", "newton", "halley", "steffensen",
+        "bisection", "regula_falsi", "ridder",
+        "illinois", "pegasus", "anderson_bjorck"};
+    for (auto name : methods) {
+        string_vector sv = make_qname(name);
+        out.insert(out.end(), sv.begin(), sv.end());
+    }
+
+    return out;
+}
+
+void broyden_test::do_operation() const
+{
+}
+
+}  // namespace standardBML
+#endif

--- a/src/module_library/module_library.cpp
+++ b/src/module_library/module_library.cpp
@@ -11,6 +11,7 @@
 #include "aba_decay.h"
 #include "ball_berry.h"
 #include "biomass_leaf_n_limitation.h"
+#include "broyden_test.h"
 #include "buck_swvp.h"
 #include "bucket_soil_drainage.h"
 #include "c3_assimilation.h"
@@ -106,6 +107,7 @@ creator_map standardBML::module_library::library_entries =
      {"aba_decay",                                             &create_mc<aba_decay>},
      {"ball_berry",                                            &create_mc<ball_berry>},
      {"biomass_leaf_n_limitation",                             &create_mc<biomass_leaf_n_limitation>},
+     {"broyden_test",                                          &create_mc<broyden_test>},
      {"buck_swvp",                                             &create_mc<buck_swvp>},
      {"bucket_soil_drainage",                                  &create_mc<bucket_soil_drainage>},
      {"c3_assimilation",                                       &create_mc<c3_assimilation>},

--- a/tests/module_test_cases/BioCro_broyden_test.csv
+++ b/tests/module_test_cases/BioCro_broyden_test.csv
@@ -1,0 +1,3 @@
+input,input,input,input,input,output,output,output,output,output,"description"
+abs_tol,guess_1,guess_2,max_iterations,rel_tol,iter,x1,x2,y1,y2,NA
+1e-10,2,3,50,1e-10,7,1.00000000000024,0.999999999999842,1.58206781009085e-13,-8.1379347705024e-14,"Simple linear/quadratic system."


### PR DESCRIPTION
This PR implements an algorithm for finding a zero of a multidimensional function (which is a solution to a nonlinear equation). This is a bit of a work-in-progress, but it's ready to be reviewed.

### The Math / Theory

Given $f:\mathbb{R}^n \to \mathbb{R}^n$, we want to find $x$ such that $f(x) = 0$. This PR implements [Broyden's good method](https://en.wikipedia.org/wiki/Broyden%27s_method)  (see also [numerical recipes](https://numerical.recipes/book.html) 9.7.3 in the 3rd ed.). Broyden's method is essentially the secant method but in more than one dimension.  

Let $df_x$ be the Jacobian (or derivative / differential) of $f$ at a point $x$. Then the secant approximation

$$
\Delta y = df_x \Delta x  + O( |\Delta x|^2)
$$

is used to approximate $df_x$. In 1D, this equation is sufficient to determine an approximation for $df_x$. In higher dimensions, the secant equation is underdetermined, so instead one uses the secant approximation to refine a guess for the Jacobian. Given $df_x \approx  J$, find the smallest change in $\Delta J$ so that $J' = J + \Delta J$ satisfies $\Delta y = J ' \Delta x $. 

1. Use $J$ to refine $x$: $x' = x - J^{-1} y $ where $y = f(x)$.
2.  Evaluate $f$ at the new point: $f(x') = y' $
3. Check if $x$ is a solution: $|y'| \leq \epsilon$ for tolerance $\epsilon$.
4. Using  $\Delta y = y' - y$ and $\Delta x = x' - x$, refine $J$ to produce a new estimate of the Jacobian $J'$

A useful trick is to refine $J^{-1}$ as a guess of $df_x^{-1}$ rather than $J$. Doing so eliminates the need to solve a linear system in step 1. The [Sherman Morrison formula](https://en.wikipedia.org/wiki/Sherman%E2%80%93Morrison_formula) can be used to generate a formula for updating $J^{-1}$.  The formula is 

$$
J^{-1} \mapsto J^{-1}  + \frac{\left(\Delta x - J^{-1} \Delta y\right) \Delta x^* J^{-1} }{\Delta x ^* J^{-1} \Delta y}
$$

Here $x^*$ denotes the dual vector/matrix (i.e., the conjugate transpose) of $x$. This is a rank-1 update since $\Delta J^{-1}$ is a rank-1 matrix.

For convergence, the eigenvalues of the approximation $J$ only needs to have the same signs as the $df_x$ (I think...). Convergence is superlinear in the neighborhood of a zero (and quadratic for Newton's method). While Broyden's method is a little slower than Newton's method in terms of the number of iterations required for convergence, However, Broyden's method can be faster in terms of computation, because it only requires one function evaluation per iteration and this version circumvents solving a linear system  / inverting a matrix. For a system of linear equations, Broyden's method produces a solution in $2n$ iterations ($n$ is the dimension); nonlinear equations take longer, roughly double I believe.

### Implementation Details

The formulas are implemented using `std::array` as the container for vectors and matrices. The user passes a function to a solver class similar to the `root_algorithm` library in PR #176. Currently this function is expected to have the signature:

```cpp
template<typename T, size_t dim>
void f(std::array<T, dim>& y, const std::array<T, dim>& x){
 y[0] = /* implementation */ ;
 y[1] = /* etc */; 
} 
```

All of the linear algebra operations are implemented as for-loops. For readability, I separated steps into methods.  I've only tested this code on 2D systems, so it might not scale well to large problems.  Currently, we have use cases which are fairly low dimensional (like <= 5). And the first major use-case is solving leaf heat and CO2 balance simultaneously, and it is only 2D.

In principle, this code should work for large systems (say dimensions > 100) but it might be slow / memory inefficient.   

### Future plans 

The main additions to this code left to do are:

1. Documentation in the code. I haven't done this part yet because the overall design might change significantly.
2. Double checking the for-loops for optimizations. 

However, it would be nice to have the interface for multidimensional solving mirror the 1D solving library. And it would be nice to easily implement new methods. Those are future goals discussed in #172.  So it might be worth translating this code into a form that's compatible with uBLAS (which we already include in BioCro) so that the linear algebra operations can be expressed using vector notation (without losing much efficiency).  I decided not to do that at first because the documentation of uBLAS is a bit sparse, so it will take some trial and error. 

It would also be nice for the solver to infer the problem's dimension from the function. But I am not yet sure how best to do that.

Some other possible modifications specific to this algorithm are:

1. A limited memory implementation. This can be more efficient in higher dimensional problems where looping over the inverse jacobian becomes slow. 
2. Line searching techniques to avoid too large or small step size. This might require solving a linear system.


Let me know what you think.


