### PR TITLE
Fix canopy photosynthesis bug ebl

### DIFF
--- a/src/module_library/FvCB_assim.cpp
+++ b/src/module_library/FvCB_assim.cpp
@@ -1,6 +1,9 @@
-#include <algorithm>  // for std::min, std::max
-#include <limits>     // for std::numeric_limits
+#include <algorithm>                 // for std::min, std::max
+#include <limits>                    // for std::numeric_limits
+#include "../framework/constants.h"  // for eps_zero
 #include "FvCB_assim.h"
+
+using calculation_constants::eps_zero;
 
 double inf = std::numeric_limits<double>::infinity();
 
@@ -132,12 +135,14 @@ FvCB_outputs FvCB_assim(
     FvCB_outputs result;
 
     // Calculate rates
-    if (Ci <= 0.0) {
+    if (Ci < 0.0) {
+        throw std::range_error("Thrown in FvCB_assim: Ci is negative.");
+    } else if (Ci <= eps_zero) {
         // RuBP-saturated net assimilation rate when Ci is 0
         double Ac0 =
             -Gstar * Vcmax / (Kc * (1 + Oi / Ko)) - RL;  // micromol / m^2 / s
 
-        // RuBP-regeneration-limited net assimilation when C is 0
+        // RuBP-regeneration-limited net assimilation when Ci is 0
         double Aj0 =
             -J / (2.0 * electrons_per_oxygenation) - RL;  // micromol / m^2 / s
 

--- a/src/module_library/FvCB_assim.cpp
+++ b/src/module_library/FvCB_assim.cpp
@@ -5,8 +5,6 @@
 
 using calculation_constants::eps_zero;
 
-double inf = std::numeric_limits<double>::infinity();
-
 /**
  *  @brief Computes the net CO2 assimilation rate (and other values) using the
  *         Farquhar-von-Caemmerer-Berry model for C3 photosynthesis.
@@ -131,6 +129,9 @@ FvCB_outputs FvCB_assim(
     double electrons_per_oxygenation     // self-explanatory units
 )
 {
+    // Define infinity
+    double const inf = std::numeric_limits<double>::infinity();
+    
     // Initialize
     FvCB_outputs result;
 

--- a/src/module_library/FvCB_assim.cpp
+++ b/src/module_library/FvCB_assim.cpp
@@ -131,12 +131,12 @@ FvCB_outputs FvCB_assim(
 {
     // Define infinity
     double const inf = std::numeric_limits<double>::infinity();
-    
+
     // Initialize
     FvCB_outputs result;
 
     // Calculate rates
-    if (Ci < 0.0) {
+    if (Ci < -eps_zero) {
         throw std::range_error("Thrown in FvCB_assim: Ci is negative.");
     } else if (Ci <= eps_zero) {
         // RuBP-saturated net assimilation rate when Ci is 0

--- a/src/module_library/ball_berry_gs.cpp
+++ b/src/module_library/ball_berry_gs.cpp
@@ -117,7 +117,7 @@ stomata_outputs ball_berry_gs(
                       (dr_boundary / gbw) * assimilation;  // mol / mol.
 
     // Check for error conditions (Cs = 0 or Cs < 0)
-    if (Cs < 0.0) {
+    if (Cs < -eps_zero) {
         throw std::range_error("Thrown in ball_berry_gs: Cs is negative.");
     } else if (Cs <= eps_zero) {
         // Stomatal conductance becomes infinite as Cs approaches zero from the

--- a/src/module_library/ball_berry_gs.cpp
+++ b/src/module_library/ball_berry_gs.cpp
@@ -116,10 +116,13 @@ stomata_outputs ball_berry_gs(
     const double Cs = ambient_c -
                       (dr_boundary / gbw) * assimilation;  // mol / mol.
 
-    // Stomatal conductance becomes infinite as Cs approaches zero from the
-    // right. In this case, there is no water vapor drawndown across the
-    // stomata, so hs becomes 1.
-    if (Cs <= eps_zero) {
+    // Check for error conditions (Cs = 0 or Cs < 0)
+    if (Cs < 0.0) {
+        throw std::range_error("Thrown in ball_berry_gs: Cs is negative.");
+    } else if (Cs <= eps_zero) {
+        // Stomatal conductance becomes infinite as Cs approaches zero from the
+        // right. In this case, there is no water vapor drawndown across the
+        // stomata, so hs becomes 1.
         double const inf = std::numeric_limits<double>::infinity();
         return stomata_outputs{
             /* .cs = */ 0,    // micromol / mol

--- a/src/module_library/c3photo.cpp
+++ b/src/module_library/c3photo.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>                    // for std::min
 #include <cmath>                        // for pow, sqrt
+#include <limits>                       // for std::numeric_limits
 #include "../framework/constants.h"     // for dr_stomata, dr_boundary
 #include "ball_berry_gs.h"              // for ball_berry_gs
 #include "c3_temperature_response.h"    // for c3_temperature_response
@@ -44,6 +45,14 @@ photosynthesis_outputs c3photoC(
     double const gbw                           // mol / m^2 / s
 )
 {
+    // Define infinity
+    double const inf = std::numeric_limits<double>::infinity();
+
+    // Check inputs
+    if (absorbed_ppfd < 0) {
+        throw std::out_of_range("Input `absorbed_ppfd` cannot be negative. Check `solar` is not negative.");
+    }
+
     // Calculate values of key parameters at leaf temperature
     c3_param_at_tleaf c3_param = c3_temperature_response(tr_param, Tleaf);
 
@@ -67,7 +76,6 @@ photosynthesis_outputs c3photoC(
     // meaning of the `Q * alpha_leaf` factor. See also Equation 8 from the
     // original FvCB paper, where `J` (equivalent to our `I2`) is proportional
     // to the absorbed PPFD rather than the incident PPFD.
-    if (absorbed_ppfd < 0) throw std::out_of_range("Input `absorbed_ppfd` cannot be negative. Check `solar` is not negative.");
     double I2 = absorbed_ppfd * dark_adapted_phi_PSII * beta_PSII;  // micromol / m^2 / s
 
     double const J =
@@ -88,23 +96,27 @@ photosynthesis_outputs c3photoC(
     // these are updated as a side effect in the secant method iterations
     FvCB_outputs FvCB_res;
     stomata_outputs BB_res;
-    double an_conductance{};  // mol / m^2 / s
-    double Gs{1e3};           // mol / m^2 / s  (initial guess)
-    double Assim{0.0};        // micromol / mol (initial guess)
+    double Gs{1e3};     // mol / m^2 / s  (initial guess)
+    double Assim{0.0};  // micromol / mol (initial guess)
 
-    // this lambda function equals zero
-    // only if assim satisfies both FvCB and Ball Berry model
-    auto check_assim_rate = [=, &FvCB_res, &BB_res, &an_conductance, &Gs, &Assim](double Ci) {
-        // Using Ci compute the assim under the FvCB
+    // This lambda function equals zero only if Ci satisfies both the FvCB and
+    // Ball-Berry models. Here, Ci should be expressed in micromol / mol.
+    auto check_assim_rate = [=, &FvCB_res, &BB_res, &Gs, &Assim](double Ci) {
+        // Use Ci to compute the assimilation rate according to the FvCB model.
         FvCB_res = FvCB_assim(
             Ci, Gstar, J, Kc, Ko, Oi, RL, TPU, Vcmax, alpha_TPU,
             electrons_per_carboxylation,
             electrons_per_oxygenation);
-        Assim = FvCB_res.An;
-        // If assim is correct, then Ball Berry gives the correct
-        // CO2 at leaf surface (Cs) and correct stomatal conductance
+
+        Assim = FvCB_res.An;  // micromol / m^2 / s
+
+        // Use Assim to compute the stomatal conductance according to the
+        // Ball-Berry model. If Assim is too high, Cs will take a negative
+        // value, which is not allowed by the Ball-Berry model. To avoid this,
+        // we clamp Assim to the value that produces Cs = 0; this will result
+        // in Gs = infinity.
         BB_res = ball_berry_gs(
-            Assim * 1e-6,
+            std::min(Assim, conductance_limited_assim(Ca, gbw, inf)) * 1e-6,
             Ca * 1e-6,
             RH,
             b0_adj,
@@ -115,12 +127,12 @@ photosynthesis_outputs c3photoC(
 
         Gs = BB_res.gsw;  // mol / m^2 / s
 
-        // Using the value of stomatal conductance,
-        // Calculate Ci using the total conductance across the boundary layer
-        // and stomata
+        // Using Ci and Gs, make a new estimate of the assimilation rate. If
+        // the initial value of Ci was correct, this should be identical to
+        // Assim.
         double Gt = 1 / (dr_boundary / gbw + dr_stomata / Gs);  // micromol / micromol / m^2 / s
 
-        return Assim - Gt * (Ca - Ci);  // equals zero if correct
+        return Assim - Gt * (Ca - Ci);  // micromol / m^2 / s
     };
 
     // Get an upper bound for Ci by finding the most negative value of An (which
@@ -131,12 +143,12 @@ photosynthesis_outputs c3photoC(
             0.0, Gstar, J, Kc, Ko, Oi, RL, TPU, Vcmax, alpha_TPU,
             electrons_per_carboxylation,
             electrons_per_oxygenation)
-            .An; // micromol / m^2 / s
+            .An;  // micromol / m^2 / s
 
     double const Ci_max =
         Ca - A_min * (dr_boundary / gbw + dr_stomata / b0_adj);  // micromol / mol
 
-    // Run the secant method
+    // Run the Dekker method
     root_algorithm::root_finder<root_algorithm::dekker> solver{500, 1e-12, 1e-12};
     root_algorithm::result_t result = solver.solve(
         check_assim_rate,
@@ -151,8 +163,9 @@ photosynthesis_outputs c3photoC(
             root_algorithm::flag_message(result.flag));
     }
 
-    double Ci = result.root;
-    an_conductance = conductance_limited_assim(Ca, gbw, Gs);
+    // Get final values
+    double const Ci = result.root;                                         // micromol / mol
+    double const an_conductance = conductance_limited_assim(Ca, gbw, Gs);  // micromol / m^2 / s
 
     return photosynthesis_outputs{
         /* .Assim = */ Assim,                       // micromol / m^2 / s

--- a/src/module_library/c4photo.cpp
+++ b/src/module_library/c4photo.cpp
@@ -18,7 +18,7 @@ using physical_constants::dr_stomata;
 
 */
 photosynthesis_outputs c4photoC(
-    double Qp,                          // micromol / m^2 / s
+    double const Qp,                    // micromol / m^2 / s
     double const leaf_temperature,      // degrees C
     double const ambient_temperature,   // degrees C
     double const relative_humidity,     // dimensionless from Pa / Pa

--- a/src/module_library/c4photo.cpp
+++ b/src/module_library/c4photo.cpp
@@ -1,4 +1,5 @@
 #include <cmath>                          // for pow, exp
+#include <limits>                         // for std::numeric_limits
 #include "../framework/constants.h"       // for dr_stomata, dr_boundary
 #include "../framework/quadratic_root.h"  // for quadratic_root_min
 #include "ball_berry_gs.h"                // for ball_berry_gs
@@ -39,13 +40,19 @@ photosynthesis_outputs c4photoC(
     double const gbw                    // mol / m^2 / s
 )
 {
-    if (Qp < 0) throw std::out_of_range("Input `absorbed_ppfd` cannot be negative. Check `solar` is not negative.");
+    // Define infinity
+    double const inf = std::numeric_limits<double>::infinity();
+
+    // Check inputs
+    if (Qp < 0) {
+        throw std::out_of_range("Input `absorbed_ppfd` cannot be negative. Check `solar` is not negative.");
+    }
 
     constexpr double k_Q10 = 2;  // dimensionless. Increase in a reaction rate per temperature increase of 10 degrees Celsius.
 
     double const Ca_pa = Ca * 1e-6 * atmospheric_pressure;  // Pa
 
-    double const kT = kparm * pow(k_Q10, (leaf_temperature - 25.0) / 10.0);  // dimensionless
+    double const kT = kparm * pow(k_Q10, (leaf_temperature - 25.0) / 10.0);  // mol / m^2 / s
 
     // Collatz 1992. Appendix B. Equation set 5B.
     double const Vtn = Vcmax_at_25 * pow(2, (leaf_temperature - 25.0) / 10.0);                                       // micromol / m^2 / s
@@ -70,7 +77,8 @@ photosynthesis_outputs c4photoC(
     double const bb0_adj = StomaWS * bb0 + Gs_min * (1.0 - StomaWS);
     double const bb1_adj = StomaWS * bb1;
 
-    // Function to compute the biochemical assimilation rate.
+    // Function to compute the biochemical assimilation rate according to the
+    // Collatz model. Here, InterCellularCO2 should be expressed in Pa.
     auto collatz_assim = [=](double const InterCellularCO2) {
         // Collatz 1992. Appendix B. Quadratic coefficients from Equation 3B.
         double kT_IC_P = kT * InterCellularCO2 / atmospheric_pressure * 1e6;  // micromol / m^2 / s
@@ -81,25 +89,29 @@ photosynthesis_outputs c4photoC(
         // Calculate the smaller of the two quadratic roots, as mentioned
         // following Equation 3B in Collatz 1992.
         double gross_assim = quadratic_root_min(a, b, c);  // micromol / m^2 / s
-        return gross_assim - RT;
+        return gross_assim - RT;                           // micromol / m^2 / s
     };
 
-    // Initialize loop variables. These will be updated as a side effect
-    // during the secant method's iterations.
-    // Here we make an initial guess that Ci = 0.4 * Ca.
+    // Initialize loop variables. These will be updated as a side effect during
+    // the secant method's iterations.
     stomata_outputs BB_res;
-    double an_conductance{};  // mol / m^2 / s
-    double Assim{0};
-    double Gs{1e3};  // mol / m^2 / s (initial guess)
+    double Assim{0};  // micromol / mol (initial guess)
+    double Gs{1e3};   // mol / m^2 / s (initial guess)
 
-    // This lambda function equals zero
-    // only if Ci satisfies its balance equation
-    auto check_assim_rate = [=, &BB_res, &an_conductance, &Assim, &Gs](double Ci_pa) {
+    // This lambda function equals zero only if Ci satisfies both the Collatz
+    // and Ball-Berry models. Here, Ci_pa should be expressed in Pa.
+    auto check_assim_rate = [=, &BB_res, &Assim, &Gs](double Ci_pa) {
+        // Use Ci to compute the assimilation rate according to the Collatz
+        // model.
         Assim = collatz_assim(Ci_pa);
-        // If assim is correct, then Ball Berry gives the correct
-        // CO2 at leaf surface (Cs) and correct stomatal conductance
+
+        // Use Assim to compute the stomatal conductance according to the
+        // Ball-Berry model. If Assim is too high, Cs will take a negative
+        // value, which is not allowed by the Ball-Berry model. To avoid this,
+        // we clamp Assim to the value that produces Cs = 0; this will result
+        // in Gs = infinity.
         BB_res = ball_berry_gs(
-            Assim * 1e-6,
+            std::min(Assim, conductance_limited_assim(Ca, gbw, inf)) * 1e-6,
             Ca * 1e-6,
             relative_humidity,
             bb0_adj,
@@ -110,14 +122,12 @@ photosynthesis_outputs c4photoC(
 
         Gs = BB_res.gsw;  // mol / m^2 / s
 
-        // Using the value of stomatal conductance,
-        // Calculate Assim using the total conductance across the boundary
-        // layer and stomata
+        // Using Ci and Gs, make a new estimate of the assimilation rate. If
+        // the initial value of Ci was correct, this should be identical to
+        // Assim.
+        double Gt = 1 / (dr_boundary / gbw + dr_stomata / Gs);  // mol / m^2 / s
 
-        double Gt = 1 / (dr_boundary / gbw + dr_stomata / Gs);  // Pa
-
-        double check = Gt * (Ca_pa - Ci_pa) / atmospheric_pressure - Assim * 1e-6;
-        return check;  // equals zero if correct
+        return Gt * (Ca_pa - Ci_pa) / atmospheric_pressure - Assim * 1e-6;  // mol / m^2 / s
     };
 
     // Max possible Ci value
@@ -125,7 +135,7 @@ photosynthesis_outputs c4photoC(
         Ca_pa + 1e-6 * atmospheric_pressure * RT *
                     (dr_boundary / gbw + dr_stomata / bb0_adj);  // Pa
 
-    // Run the illinois method
+    // Run the Dekker method
     root_algorithm::root_finder<root_algorithm::dekker> solver{500, 1e-12, 1e-12};
     root_algorithm::result_t result = solver.solve(
         check_assim_rate,
@@ -140,10 +150,10 @@ photosynthesis_outputs c4photoC(
             root_algorithm::flag_message(result.flag));
     }
 
-    // Convert Ci units
-    double const Ci = result.root / atmospheric_pressure * 1e6;  // micromol / mol
+    // Get final values
+    double const Ci = result.root / atmospheric_pressure * 1e6;            // micromol / mol
+    double const an_conductance = conductance_limited_assim(Ca, gbw, Gs);  // micromol / m^2 / s
 
-    an_conductance = conductance_limited_assim(Ca, gbw, Gs);
     return photosynthesis_outputs{
         /* .Assim = */ Assim,                       // micromol / m^2 /s
         /* .Assim_check = */ result.residual,       // micromol / m^2 / s

--- a/src/module_library/c4photo.cpp
+++ b/src/module_library/c4photo.cpp
@@ -39,7 +39,6 @@ photosynthesis_outputs c4photoC(
     double const gbw                    // mol / m^2 / s
 )
 {
-
     if (Qp < 0) throw std::out_of_range("Input `absorbed_ppfd` cannot be negative. Check `solar` is not negative.");
 
     constexpr double k_Q10 = 2;  // dimensionless. Increase in a reaction rate per temperature increase of 10 degrees Celsius.
@@ -122,8 +121,9 @@ photosynthesis_outputs c4photoC(
     };
 
     // Max possible Ci value
-    double const Ci_max = Ca_pa + 1e-6 * atmospheric_pressure * RT
-        * (dr_boundary / gbw + dr_stomata / bb0_adj);
+    double const Ci_max =
+        Ca_pa + 1e-6 * atmospheric_pressure * RT *
+                    (dr_boundary / gbw + dr_stomata / bb0_adj);  // Pa
 
     // Run the illinois method
     root_algorithm::root_finder<root_algorithm::dekker> solver{500, 1e-12, 1e-12};
@@ -131,14 +131,13 @@ photosynthesis_outputs c4photoC(
         check_assim_rate,
         0.5 * Ca_pa,
         0,
-        Ci_max *1.01);
+        Ci_max * 1.01);
 
     // throw exception if not converged
-    if ( ! root_algorithm::is_successful(result.flag) ) {
+    if (!root_algorithm::is_successful(result.flag)) {
         throw std::runtime_error(
             "Ci solver reports failed convergence with termination flag:\n    " +
-            root_algorithm::flag_message(result.flag)
-        );
+            root_algorithm::flag_message(result.flag));
     }
 
     // Convert Ci units

--- a/src/module_library/c4photo.h
+++ b/src/module_library/c4photo.h
@@ -4,7 +4,7 @@
 #include "photosynthesis_outputs.h"  // for photosynthesis_outputs
 
 photosynthesis_outputs c4photoC(
-    double Qp,
+    double const Qp,
     double const leaf_temperature,
     double const ambient_temperature,
     double const relative_humidity,


### PR DESCRIPTION
The major change in this PR is that I have reinstated the range errors in the FvCB and Ball-Berry model functions, instead of allowing negative `Ci` and `Cs`.

Of course, after doing this, there were lots of "negative Cs" errors. I addressed them by clamping the value of `Assim` passed to the Ball-Berry function in `c3photoC` and `c4photoC`. Nothing needed to be done about negative `Ci`, since the Dekker solver never passes such values. But, if another solver were used and this became a problem, `std::max(0.0, Ci)` could be passed to `FvCB_assim` instead of just `Ci`.

No tests needed to be changed, so this produces mostly the same behavior as on the `fix-canopy-photosynthesis-bug` branch. The main difference is that here the solver is responsible for ensuring that bad inputs are not passed to the Ball-Berry function, rather than the Ball-Berry function silently treating `Cs < 0` as if it were `Cs = 0`.

I think this approach is safer, since there may be contexts where treating `Cs < 0` as if it were `Cs = 0` in the Ball-Berry model could be problematic.