### PR TITLE
Minor change to root solving

### DIFF
--- a/src/module_library/boundary_layer_conductance.cpp
+++ b/src/module_library/boundary_layer_conductance.cpp
@@ -3,7 +3,7 @@
 #include "root_onedim.h"               // for root_finder
 #include "water_and_air_properties.h"  // for saturation_vapor_pressure
 #include "boundary_layer_conductance.h"
-#include <iomanip>
+
 /**
  *  @brief Calculates the conductance for water vapor flow from the leaf across
  *  its boundary layer using a model described in Nikolov, Massman, and

--- a/src/module_library/boundary_layer_conductance.cpp
+++ b/src/module_library/boundary_layer_conductance.cpp
@@ -3,7 +3,7 @@
 #include "root_onedim.h"               // for root_finder
 #include "water_and_air_properties.h"  // for saturation_vapor_pressure
 #include "boundary_layer_conductance.h"
-
+#include <iomanip>
 /**
  *  @brief Calculates the conductance for water vapor flow from the leaf across
  *  its boundary layer using a model described in Nikolov, Massman, and
@@ -108,7 +108,7 @@ double leaf_boundary_layer_conductance_nikolov(
 
     root_algorithm::result_t result = solver.solve(
         check_leaf_gbv_free,
-        0,   // first guess
+        0.0001,   // first guess
         0,   // lower bound of initial bracket
         0.5  // upper bound of initial bracket
     );
@@ -116,8 +116,8 @@ double leaf_boundary_layer_conductance_nikolov(
     // Throw exception if not converged
     if (!root_algorithm::is_successful(result.flag)) {
         throw std::runtime_error(
-            "gbv_free solver reports failed convergence with termination flag:\n    " +
-            root_algorithm::flag_message(result.flag));
+           root_algorithm::error_message(result,  "gbv_free solver reports failed convergence with termination flag")
+        );
     }
 
     // Get final value

--- a/src/module_library/root_onedim.h
+++ b/src/module_library/root_onedim.h
@@ -4,6 +4,8 @@
 #include <cmath>
 #include <limits>
 #include <string>
+#include <sstream>
+#include <iomanip>
 
 /**
  * A C++ library for solving 1D equations.
@@ -73,6 +75,7 @@ struct result_t {
     size_t iteration;
     Flag flag;
 };
+inline std::string error_message(const result_t& r, std::string prefix);
 
 /**
  * @class root_finder
@@ -1251,6 +1254,18 @@ std::string flag_message(Flag flag)
         default:
             return "Flag not recognized.";
     }
+}
+
+std::string error_message(const result_t& r, std::string prefix = ""){
+    std::stringstream out;
+    out << prefix << ":\n  ";
+    out << flag_message(r.flag) << "\n    ";
+    out << "Flag = " << static_cast<int>(r.flag) << "\n    ";
+    out << std::setprecision(20);
+    out << "Root = " << r.root << "\n    ";
+    out << "Residual = " << r.residual << "\n    ";
+    out << "Iteration = " << r.iteration << '\n';
+    return out.str();
 }
 
 }  // namespace root_algorithm


### PR DESCRIPTION
@eloch216  This code passes the convergence check. I made a PR to make it easy to see the differences. Feel free to reject this and modify #208 directly. 

I modified the error message so that any non successful flag prints out the `residual` and `root`. As you suspected, this is an issue with the convergence check. This makes it easier to judge whether errors are spurious or not. And what to investigate.

THe bracket width's tolerance check needs to change but that's going to take a few more minutes to think through. 

By the way, if you use the 3 point start to Dekker's method, I would use three different points. I suspect this just gives a better start for the secant method. 