### PR TITLE
Enable `changes-meaning` compiler warnings

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,4 @@
-PKG_CPPFLAGS+=-I../src/inc -DR_NO_REMAP
+PKG_CPPFLAGS+=-I../src/inc -DR_NO_REMAP -Wchanges-meaning
 
 SOURCES = $(wildcard *.cpp module_library/*.cpp framework/*.cpp framework/ode_solver_library/*.cpp framework/utils/*.cpp math/roots/onedim/*.cpp)
 OBJECTS = $(SOURCES:.cpp=.o)


### PR DESCRIPTION
A test to see if we can detect these warnings in our checking workflow