### PR TITLE
Change oldest R version for MacOS testing

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -59,7 +59,7 @@ on:
           - R 4.1.0 on Ubuntu
           - R release version on Ubuntu
           - R devel version on Ubuntu
-          - R 4.2.0 on macOS
+          - R 4.2.3 on macOS
           - R release version on macOS
           - R 4.1.0 on Windows
           - R release version on Windows

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -59,7 +59,7 @@ on:
           - R 4.1.0 on Ubuntu
           - R release version on Ubuntu
           - R devel version on Ubuntu
-          - R 4.2.3 on macOS
+          - R 4.3.0 on macOS
           - R release version on macOS
           - R 4.1.0 on Windows
           - R release version on Windows

--- a/.github/workflows/strategy_matrix.json
+++ b/.github/workflows/strategy_matrix.json
@@ -5,9 +5,9 @@
         "r": "4.1.0"
     },
     {
-        "configName": "R 4.2.0 on macOS",
+        "configName": "R 4.2.3 on macOS",
         "os": "macOS-latest",
-        "r": "4.2.0"
+        "r": "4.2.3"
     },
     {
         "configName": "R 4.1.0 on Ubuntu",

--- a/.github/workflows/strategy_matrix.json
+++ b/.github/workflows/strategy_matrix.json
@@ -5,9 +5,9 @@
         "r": "4.1.0"
     },
     {
-        "configName": "R 4.2.3 on macOS",
+        "configName": "R 4.3.0 on macOS",
         "os": "macOS-latest",
-        "r": "4.2.3"
+        "r": "4.3.0"
     },
     {
         "configName": "R 4.1.0 on Ubuntu",

--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,20 @@ In the case of a hotfix, a short section headed by the new release number should
 be directly added to this file to describe the related changes.
 -->
 
+# UNRELEASED
+
+## Bug Fixes
+
+- Changed the minimum version of macOS checked by the R-CMD-check from
+  4.2.0 to 4.3.0.
+
+  - CRAN now only provides R versions 4.2.3 and above for Mac.
+
+  - Somehow the vignette builder cannot find the `knitr` package when using the
+    the online testing setup for R version 4.2.0 or 4.2.3 even when `knitr` is
+    installed, causing a spurious test failure. This problem does not occur for
+    R version 4.3.0.
+
 # Changes in BioCro version 3.3.1
 
 ## Bug fixes


### PR DESCRIPTION
The CRAN MacOS binary repository (https://cran.r-project.org/bin/macosx/) no longer offers v4.2.0, and the earliest version is v4.2.3. Maybe changing to this version will solve the problem.

This is pretty much a wild guess, but we were able to solve another testing problem in the past by changing to v4.2.0. So maybe it will help again.