### PR TITLE
Lower maxlay -- refactor to make MAXLAY a local variable

### DIFF
--- a/src/module_library/CanAC.cpp
+++ b/src/module_library/CanAC.cpp
@@ -130,7 +130,6 @@ canopy_photosynthesis_outputs CanAC(
         // energy balance to get a better temperature estimate using that value
         // of stomatal conductance. Get the final estimate of stomatal
         // conductance using the new value of the leaf temperature.
-        double pLeafsun = light_profile.sunlit_fraction[current_layer];         // dimensionless. Fraction of LAI that is sunlit.
         double i_dir = light_layer.sunlit_incident_ppfd;       // micromol / m^2 / s
         double j_dir = light_layer.sunlit_absorbed_shortwave;  // J / m^2 / s
         double pLeafsun = light_layer.sunlit_fraction;         // dimensionless. Fraction of LAI that is sunlit.

--- a/src/module_library/CanAC.cpp
+++ b/src/module_library/CanAC.cpp
@@ -65,7 +65,7 @@ canopy_photosynthesis_outputs CanAC(
 
     // Here we set `heightf = 1`. The value used for `heightf` does not matter,
     // since the canopy height is not used anywhere in this function.
-    struct Light_profile light_profile = sunML(
+    const LightProfile light_profile = sunML(
         q_dir,
         q_diff,
         chil,
@@ -124,15 +124,16 @@ canopy_photosynthesis_outputs CanAC(
         }
 
         double layer_wind_speed = wind_speed_profile[current_layer];  // m / s
-
+        const LightProfile::Layer& light_layer = light_profile[current_layer];
         // Calculations for sunlit leaves. First, estimate stomatal conductance
         // by assuming the leaf has the same temperature as the air. Then, use
         // energy balance to get a better temperature estimate using that value
         // of stomatal conductance. Get the final estimate of stomatal
         // conductance using the new value of the leaf temperature.
-        double i_dir = light_profile.sunlit_incident_ppfd[current_layer];       // micromol / m^2 / s
-        double j_dir = light_profile.sunlit_absorbed_shortwave[current_layer];  // J / m^2 / s
         double pLeafsun = light_profile.sunlit_fraction[current_layer];         // dimensionless. Fraction of LAI that is sunlit.
+        double i_dir = light_layer.sunlit_incident_ppfd;       // micromol / m^2 / s
+        double j_dir = light_layer.sunlit_absorbed_shortwave;  // J / m^2 / s
+        double pLeafsun = light_layer.sunlit_fraction;         // dimensionless. Fraction of LAI that is sunlit.
         double Leafsun = LAIc * pLeafsun;                                       // dimensionless
 
         double direct_gsw_estimate =
@@ -182,9 +183,9 @@ canopy_photosynthesis_outputs CanAC(
         // energy balance to get a better temperature estimate using that value
         // of stomatal conductance. Get the final estimate of stomatal
         // conductance using the new value of the leaf temperature.
-        double i_diff = light_profile.shaded_incident_ppfd[current_layer];       // micromol / m^2 / s
-        double j_diff = light_profile.shaded_absorbed_shortwave[current_layer];  // J / m^2 / s
-        double pLeafshade = light_profile.shaded_fraction[current_layer];        // dimensionless. Fraction of LAI that is shaded.
+        double i_diff = light_layer.shaded_incident_ppfd;       // micromol / m^2 / s
+        double j_diff = light_layer.shaded_absorbed_shortwave;  // J / m^2 / s
+        double pLeafshade = light_layer.shaded_fraction;        // dimensionless. Fraction of LAI that is shaded.
         double Leafshade = LAIc * pLeafshade;                                    // dimensionless
 
         double diffuse_gsw_estimate =

--- a/src/module_library/c3CanAC.cpp
+++ b/src/module_library/c3CanAC.cpp
@@ -69,7 +69,7 @@ canopy_photosynthesis_outputs c3CanAC(
     double const q_dir = light_model.direct_fraction * solarR;    // micromol / m^2 / s
     double const q_diff = light_model.diffuse_fraction * solarR;  // micromol / m^2 / s
 
-    const Light_profile light_profile = sunML(
+    const LightProfile light_profile = sunML(
         q_dir,
         q_diff,
         chil,
@@ -125,14 +125,15 @@ canopy_photosynthesis_outputs c3CanAC(
 
         double layer_wind_speed = wind_speed_profile[current_layer];  // m / s
 
+        const LightProfile::Layer& light_layer = light_profile[current_layer];
         // Calculations for sunlit leaves. First, estimate stomatal conductance
         // by assuming the leaf has the same temperature as the air. Then, use
         // energy balance to get a better temperature estimate using that value
         // of stomatal conductance. Get the final estimate of stomatal
         // conductance using the new value of the leaf temperature.
-        double iabs_dir = light_profile.sunlit_absorbed_ppfd[current_layer];    // micromol / m^2 / s
-        double j_dir = light_profile.sunlit_absorbed_shortwave[current_layer];  // J / m^2 / s
-        double pLeafsun = light_profile.sunlit_fraction[current_layer];         // dimensionless
+        double iabs_dir = light_layer.sunlit_absorbed_ppfd;    // micromol / m^2 / s
+        double j_dir = light_layer.sunlit_absorbed_shortwave;  // J / m^2 / s
+        double pLeafsun = light_layer.sunlit_fraction;         // dimensionless
         double Leafsun = LAIc * pLeafsun;                                       // dimensionless
 
         // Initial guess
@@ -186,9 +187,9 @@ canopy_photosynthesis_outputs c3CanAC(
         // energy balance to get a better temperature estimate using that value
         // of stomatal conductance. Get the final estimate of stomatal
         // conductance using the new value of the leaf temperature.
-        double iabs_diff = light_profile.shaded_absorbed_ppfd[current_layer];    // micromol / m^2 /s
-        double j_diff = light_profile.shaded_absorbed_shortwave[current_layer];  // J / m^2 / s
-        double pLeafshade = light_profile.shaded_fraction[current_layer];        // dimensionless
+        double iabs_diff = light_layer.shaded_absorbed_ppfd;    // micromol / m^2 /s
+        double j_diff = light_layer.shaded_absorbed_shortwave;  // J / m^2 / s
+        double pLeafshade = light_layer.shaded_fraction;        // dimensionless
         double Leafshade = LAIc * pLeafshade;                                    // dimensionless
 
         // Initial guess

--- a/src/module_library/multilayer_canopy_properties.cpp
+++ b/src/module_library/multilayer_canopy_properties.cpp
@@ -107,7 +107,7 @@ void multilayer_canopy_properties::run() const
     // that the `sunML` function expects input expects PPFD values, so we must
     // convert photosynthetically active radiation (PAR) to PPFD using the
     // energy content of light in the PAR band
-    struct Light_profile light_profile = sunML(
+    const LightProfile light_profile = sunML(
         par_incident_direct / par_energy_content,   // micromol / (m^2 beam) / s
         par_incident_diffuse / par_energy_content,  // micromol / m^2 / s
         chil,
@@ -138,19 +138,20 @@ void multilayer_canopy_properties::run() const
 
     // Update layer-dependent outputs
     for (int i = 0; i < nlayers; ++i) {
-        update(sunlit_fraction_ops[i], light_profile.sunlit_fraction[i]);
-        update(sunlit_incident_nir_ops[i], light_profile.sunlit_incident_nir[i]);
-        update(sunlit_incident_ppfd_ops[i], light_profile.sunlit_incident_ppfd[i]);
-        update(sunlit_absorbed_ppfd_ops[i], light_profile.sunlit_absorbed_ppfd[i]);
-        update(sunlit_absorbed_shortwave_ops[i], light_profile.sunlit_absorbed_shortwave[i]);
+        const LightProfile::Layer& light_layer = light_profile[i];
+        update(sunlit_fraction_ops[i], light_layer.sunlit_fraction);
+        update(sunlit_incident_nir_ops[i], light_layer.sunlit_incident_nir);
+        update(sunlit_incident_ppfd_ops[i], light_layer.sunlit_incident_ppfd);
+        update(sunlit_absorbed_ppfd_ops[i], light_layer.sunlit_absorbed_ppfd);
+        update(sunlit_absorbed_shortwave_ops[i], light_layer.sunlit_absorbed_shortwave);
 
-        update(shaded_fraction_ops[i], light_profile.shaded_fraction[i]);
-        update(shaded_incident_nir_ops[i], light_profile.shaded_incident_nir[i]);
-        update(shaded_incident_ppfd_ops[i], light_profile.shaded_incident_ppfd[i]);
-        update(shaded_absorbed_ppfd_ops[i], light_profile.shaded_absorbed_ppfd[i]);
-        update(shaded_absorbed_shortwave_ops[i], light_profile.shaded_absorbed_shortwave[i]);
+        update(shaded_fraction_ops[i], light_layer.shaded_fraction);
+        update(shaded_incident_nir_ops[i], light_layer.shaded_incident_nir);
+        update(shaded_incident_ppfd_ops[i], light_layer.shaded_incident_ppfd);
+        update(shaded_absorbed_ppfd_ops[i], light_layer.shaded_absorbed_ppfd);
+        update(shaded_absorbed_shortwave_ops[i], light_layer.shaded_absorbed_shortwave);
 
-        update(height_ops[i], light_profile.height[i]);
+        update(height_ops[i], light_layer.height);
         update(windspeed_ops[i], wind_speed_profile[i]);
         update(LeafN_ops[i], leafN_profile[i]);
     }

--- a/src/module_library/sunML.cpp
+++ b/src/module_library/sunML.cpp
@@ -1,5 +1,6 @@
 #include "sunML.h"
-
+using std::exp;
+using std::sqrt;
 /**
  *  @brief Computes absorbed light from incident light for a thin layer of
  *  material.
@@ -422,8 +423,8 @@ Light_profile sunML(
     int nlayers                     // dimensionless
 )
 {
-    if (nlayers < 1 || nlayers > MAXLAY) {
-        throw std::out_of_range("nlayers must be at least 1 but no more than MAXLAY.");
+    if (nlayers < 1 || nlayers > Light_profile::max_layers) {
+        throw std::out_of_range("nlayers must be at least 1 but no more than " + std::to_string(Light_profile::max_layers));
     }
 
     if (cosine_zenith_angle > 1 || cosine_zenith_angle < -1) {

--- a/src/module_library/sunML.cpp
+++ b/src/module_library/sunML.cpp
@@ -1,6 +1,8 @@
 #include "sunML.h"
+
 using std::exp;
 using std::sqrt;
+
 /**
  *  @brief Computes absorbed light from incident light for a thin layer of
  *  material.

--- a/src/module_library/sunML.cpp
+++ b/src/module_library/sunML.cpp
@@ -408,7 +408,7 @@ double shaded_radiation(
  *          the canopy, including several photon flux densities and
  *          the relative fractions of shaded and sunlit leaves
  */
-Light_profile sunML(
+LightProfile sunML(
     double ambient_ppfd_beam,       // micromol / (m^2 beam) / s
     double ambient_ppfd_diffuse,    // micromol / m^2 / s
     double chil,                    // dimensionless from m^2 / m^2
@@ -425,8 +425,8 @@ Light_profile sunML(
     int nlayers                     // dimensionless
 )
 {
-    if (nlayers < 1 || nlayers > Light_profile::max_layers) {
-        throw std::out_of_range("nlayers must be at least 1 but no more than " + std::to_string(Light_profile::max_layers));
+    if (nlayers < 1) {
+        throw std::out_of_range("nlayers must be at least 1");
     }
 
     if (cosine_zenith_angle > 1 || cosine_zenith_angle < -1) {
@@ -500,7 +500,7 @@ Light_profile sunML(
         ambient_ppfd_beam_leaf, par_energy_content, par_energy_fraction);  // J / (m^2 leaf) / s
 
     // Start to fill in the light profile values
-    Light_profile light_profile;
+    LightProfile light_profile(nlayers);
     light_profile.canopy_direct_transmission_fraction = canopy_direct_transmission_fraction;
 
     // Fill in the layer-dependent light profile values
@@ -539,29 +539,30 @@ Light_profile sunML(
         }
 
         // Store values of incident PPFD
-        light_profile.height[i] = (lai - cumulative_lai) / heightf;                    // m
-        light_profile.shaded_fraction[i] = shaded_fraction;                            // dimensionless from m^2 / m^2
-        light_profile.shaded_incident_ppfd[i] = shaded_ppfd;                           // micromol / (m^2 leaf) / s
-        light_profile.shaded_incident_nir[i] = shaded_nir;                             // J / (m^2 leaf) / s
-        light_profile.sunlit_fraction[i] = sunlit_fraction;                            // dimensionless from m^2 / m^2
-        light_profile.sunlit_incident_ppfd[i] = ambient_ppfd_beam_leaf + shaded_ppfd;  // micromol / (m^2 leaf) / s
-        light_profile.sunlit_incident_nir[i] = ambient_nir_beam_leaf + shaded_nir;     // J / (m^2 leaf) / s
+        LightProfile::Layer& layer = light_profile[i];
+        layer.height = (lai - cumulative_lai) / heightf;                    // m
+        layer.shaded_fraction = shaded_fraction;                            // dimensionless from m^2 / m^2
+        layer.shaded_incident_ppfd = shaded_ppfd;                           // micromol / (m^2 leaf) / s
+        layer.shaded_incident_nir = shaded_nir;                             // J / (m^2 leaf) / s
+        layer.sunlit_fraction = sunlit_fraction;                            // dimensionless from m^2 / m^2
+        layer.sunlit_incident_ppfd = ambient_ppfd_beam_leaf + shaded_ppfd;  // micromol / (m^2 leaf) / s
+        layer.sunlit_incident_nir = ambient_nir_beam_leaf + shaded_nir;     // J / (m^2 leaf) / s
 
         // Store values of absorbed PPFD
-        light_profile.sunlit_absorbed_ppfd[i] =
+        layer.sunlit_absorbed_ppfd =
             thin_layer_absorption(
                 leaf_reflectance_par,
                 leaf_transmittance_par,
                 ambient_ppfd_beam_leaf + shaded_ppfd);  // micromol / m^2 / s
 
-        light_profile.shaded_absorbed_ppfd[i] =
+        layer.shaded_absorbed_ppfd  =
             thin_layer_absorption(
                 leaf_reflectance_par,
                 leaf_transmittance_par,
                 shaded_ppfd);  // micromol / m^2 / s
 
         // Store values of absorbed solar energy (including PAR and NIR)
-        light_profile.sunlit_absorbed_shortwave[i] =
+        layer.sunlit_absorbed_shortwave =
             absorbed_shortwave(
                 ambient_nir_beam_leaf + shaded_nir,
                 ambient_ppfd_beam_leaf + shaded_ppfd,
@@ -571,7 +572,7 @@ Light_profile sunML(
                 leaf_reflectance_nir,
                 leaf_transmittance_nir);  // J / (m^2 leaf) / s
 
-        light_profile.shaded_absorbed_shortwave[i] =
+        layer.shaded_absorbed_shortwave =
             absorbed_shortwave(
                 shaded_nir,
                 shaded_ppfd,

--- a/src/module_library/sunML.h
+++ b/src/module_library/sunML.h
@@ -4,21 +4,48 @@
 #include <string>
 #include <cmath>
 #include <stdexcept>
+#include <vector>
 
-struct Light_profile {
-    static constexpr int max_layers = 25;
+struct LightProfile {
+    struct Layer {
+        double height;                       // m
+        double shaded_absorbed_ppfd;         // micromol / (m^2 leaf) / s
+        double shaded_absorbed_shortwave;    // J / (m^2 leaf) / s
+        double shaded_fraction;              // dimensionless
+        double shaded_incident_nir;          // J / (m^2 leaf) / s
+        double shaded_incident_ppfd;         // micromol / (m^2 leaf) / s
+        double sunlit_absorbed_ppfd;         // micromol / (m^2 leaf) / s
+        double sunlit_absorbed_shortwave;    // J / (m^2 leaf) / s
+        double sunlit_fraction;              // dimensionless
+        double sunlit_incident_nir;          // J / (m^2 leaf) / s
+        double sunlit_incident_ppfd;         // micromol / (m^2 leaf) / s
+    };
+
     double canopy_direct_transmission_fraction;  // dimensionless
-    double height[max_layers];                       // m
-    double shaded_absorbed_ppfd[max_layers];         // micromol / (m^2 leaf) / s
-    double shaded_absorbed_shortwave[max_layers];    // J / (m^2 leaf) / s
-    double shaded_fraction[max_layers];              // dimensionless
-    double shaded_incident_nir[max_layers];          // J / (m^2 leaf) / s
-    double shaded_incident_ppfd[max_layers];         // micromol / (m^2 leaf) / s
-    double sunlit_absorbed_ppfd[max_layers];         // micromol / (m^2 leaf) / s
-    double sunlit_absorbed_shortwave[max_layers];    // J / (m^2 leaf) / s
-    double sunlit_fraction[max_layers];              // dimensionless
-    double sunlit_incident_nir[max_layers];          // J / (m^2 leaf) / s
-    double sunlit_incident_ppfd[max_layers];         // micromol / (m^2 leaf) / s
+
+    std::vector<Layer> layers;
+
+    // default initialize to nlayers
+    explicit LightProfile(size_t nlayers) : layers(nlayers) {}
+
+    size_t nlayers() const { return layers.size(); }
+
+    Layer& operator[](size_t idx) {
+        return layers[idx];
+    }
+
+    const Layer& operator[](size_t idx) const {
+        return layers[idx];
+    }
+
+    // with bounds checking
+    Layer& at(size_t idx) {
+        return layers.at(idx);
+    }
+
+    const Layer& at(size_t idx) const {
+        return layers.at(idx);
+    }
 };
 
 double thin_layer_absorption(
@@ -74,7 +101,7 @@ double shaded_radiation(
     double ell         // dimensionless from m^2 leaf / m^2 ground
 );
 
-Light_profile sunML(
+LightProfile sunML(
     double ambient_ppfd_beam,       // micromol / (m^2 beam) / s
     double ambient_ppfd_diffuse,    // micromol / m^2 / s
     double chil,                    // dimensionless from m^2 / m^2

--- a/src/module_library/sunML.h
+++ b/src/module_library/sunML.h
@@ -1,21 +1,25 @@
 #ifndef SUNML_H
 #define SUNML_H
+// #include "AuxBioCro.h"  // for MAXLAY
 
-#include "AuxBioCro.h"  // for MAXLAY
+#include <string>
+#include <cmath>
+#include <stdexcept>
 
 struct Light_profile {
+    static constexpr int max_layers = 200;
     double canopy_direct_transmission_fraction;  // dimensionless
-    double height[MAXLAY];                       // m
-    double shaded_absorbed_ppfd[MAXLAY];         // micromol / (m^2 leaf) / s
-    double shaded_absorbed_shortwave[MAXLAY];    // J / (m^2 leaf) / s
-    double shaded_fraction[MAXLAY];              // dimensionless
-    double shaded_incident_nir[MAXLAY];          // J / (m^2 leaf) / s
-    double shaded_incident_ppfd[MAXLAY];         // micromol / (m^2 leaf) / s
-    double sunlit_absorbed_ppfd[MAXLAY];         // micromol / (m^2 leaf) / s
-    double sunlit_absorbed_shortwave[MAXLAY];    // J / (m^2 leaf) / s
-    double sunlit_fraction[MAXLAY];              // dimensionless
-    double sunlit_incident_nir[MAXLAY];          // J / (m^2 leaf) / s
-    double sunlit_incident_ppfd[MAXLAY];         // micromol / (m^2 leaf) / s
+    double height[max_layers];                       // m
+    double shaded_absorbed_ppfd[max_layers];         // micromol / (m^2 leaf) / s
+    double shaded_absorbed_shortwave[max_layers];    // J / (m^2 leaf) / s
+    double shaded_fraction[max_layers];              // dimensionless
+    double shaded_incident_nir[max_layers];          // J / (m^2 leaf) / s
+    double shaded_incident_ppfd[max_layers];         // micromol / (m^2 leaf) / s
+    double sunlit_absorbed_ppfd[max_layers];         // micromol / (m^2 leaf) / s
+    double sunlit_absorbed_shortwave[max_layers];    // J / (m^2 leaf) / s
+    double sunlit_fraction[max_layers];              // dimensionless
+    double sunlit_incident_nir[max_layers];          // J / (m^2 leaf) / s
+    double sunlit_incident_ppfd[max_layers];         // micromol / (m^2 leaf) / s
 };
 
 double thin_layer_absorption(

--- a/src/module_library/sunML.h
+++ b/src/module_library/sunML.h
@@ -6,7 +6,7 @@
 #include <stdexcept>
 
 struct Light_profile {
-    static constexpr int max_layers = 200;
+    static constexpr int max_layers = 25;
     double canopy_direct_transmission_fraction;  // dimensionless
     double height[max_layers];                       // m
     double shaded_absorbed_ppfd[max_layers];         // micromol / (m^2 leaf) / s

--- a/src/module_library/sunML.h
+++ b/src/module_library/sunML.h
@@ -1,6 +1,5 @@
 #ifndef SUNML_H
 #define SUNML_H
-// #include "AuxBioCro.h"  // for MAXLAY
 
 #include <string>
 #include <cmath>


### PR DESCRIPTION
So the `Light_profile` struct in `sunML.h`  allocates arrays of size 200 for 200 layers even though we only use 10 layers for default biocro.   I created this branch to test whether or not those extra memory allocations have a significant impact on speed. 

The answer seems to be no. Changing the number of layers seems to have a negligible effect. I got very different speeds running from command line vs. running from Rstudio. The test script is below. 

That said, I am still making a PR because I made a small change to the code which improves its readability IMO.   Because AFAIK, MAXLAY is not used anywhere other than inside light_profile, I replaced it with a static, constant  expression integer `max_layers` defined in the `Light_profile` struct.  As a result, the `AuxBio.h` is not needed (I think ultimately that file should be deleted and anything we still use should be moved elsewhere). This makes the `sunML.h` and `sunML.cpp` marginally more modular.  

Long term there are other changes I would make, but those aren't a priority. 

 
```r
library(BioCro)
library(microbenchmark)

runit <- function(ode_solver) {
  run_biocro(
    soybean$initial_values,
    soybean$parameters,
    soybean_weather[['2006']],
    soybean$direct_modules,
    soybean$differential_modules,
    default_ode_solvers[[ode_solver]]
  )
}

res <- microbenchmark(
  runit("boost_euler"),
  runit("boost_rkck54")
  times = 10L
)
```
