### PR TITLE
Added some documentation to the multidimensional roots library

### DIFF
--- a/src/math/roots/multidim/broyden.h
+++ b/src/math/roots/multidim/broyden.h
@@ -7,37 +7,91 @@
 namespace root_multidim
 {
 
-/** @brief Broyden's method.
+/**
+ * @brief Broyden's method for finding vector-valued zeros of nonlinear systems.
  *
- *  @details
+ * This struct implements Broyden's "good" method — a quasi-Newton root-finding
+ * algorithm that approximates the Jacobian inverse iteratively, avoiding the
+ * cost of computing or factoring a full Jacobian at every step.
+ *
+ * @tparam Dim The dimension of the system (number of equations = number of unknowns).
+ *
+ * @par Usage Example
+ * @code
+ * // Define the system: find x such that f(x) = 0
+ * auto f = [](std::array<double, 2> x) -> std::array<double, 2> {
+ *     return { x[0]*x[0] + x[1] - 1.0,
+ *              x[0]      - x[1]*x[1] };
+ * };
+ * using namespace root_multidim;
+ * // set solver with a max iterations, abs_tol, rel_rol
+ * broyden<2> solver(100, 1e-5, 1e-5);
+ * std::array<double, 2> guess = { 0.5, 0.5 };
+ *
+ * result_t result = solver.solve(f, guess);
+ *
+ * @endcode
+ *
+ * @note The inverse Jacobian is initialised to the identity matrix, so the
+ *       first step is equivalent to a Newton step with @f$ J = I @f$.
+ *       Convergence may be slow if the true Jacobian at the starting point
+ *       differs greatly from the identity.
  */
 template <size_t Dim>
 struct broyden : public zero_finding_method<Dim, broyden<Dim>> {
+    // zero_finding_method methods can call private methods defined here
+    friend class zero_finding_method<Dim, broyden<Dim>>::zero_finding_method;
+
+    // "import" parent class methods
     using zero_finding_method<Dim, broyden<Dim>>::zero_finding_method;
-    using vec_t = typename linalg::vector<double, Dim>;
-    using mat_t = typename linalg::matrix<double, Dim, Dim>;
 
-    vec_t _zero;
-    vec_t _residual;
-    vec_t delta_x;
-    vec_t delta_y;
-    mat_t inv_jac;
+   private:
+    // --- type aliases -------------------------------------------------------
+    using vec_t = typename linalg::vector<double, Dim>;       ///< Dense vector type.
+    using mat_t = typename linalg::matrix<double, Dim, Dim>;  ///< Dense matrix type.
 
-    vec_t _tmp_a;
-    vec_t _tmp_b;
-    double _tmp_c;
+    // --- state -----------------------------------------------------------------
+
+    vec_t _zero;      ///< Current best estimate of the zero.
+    vec_t _residual;  ///< Residual f(_zero) at the current estimate.
+    vec_t delta_x;    ///< Last step taken in x-space.
+    vec_t delta_y;    ///< Change in residual across the last step.
+    mat_t inv_jac;    ///< Running approximation of the inverse Jacobian.
+
+    // --- internal temporaries (avoid per-iteration allocation) ----------------
+
+    vec_t _tmp_a;   ///< @private Numerator row  in the rank-1 update.
+    vec_t _tmp_b;   ///< @private Numerator col  in the rank-1 update.
+    double _tmp_c;  ///< @private Denominator scalar in the rank-1 update.
 
     template <typename F>
-    bool initialize(F&& fun, std::array<double, Dim> const& guess)
+    Status initialize(F&& fun, std::array<double, Dim> const& guess)
     {
         _zero = guess;
         _residual = fun(guess);
         inv_jac = linalg::matrix<double, Dim, Dim>::identity();
-        return true;
+        return Status::ok;
     }
-
+    /**
+     * @brief Performs one Broyden iteration.
+     *
+     * Advances the current estimate by one quasi-Newton step and updates the
+     * inverse-Jacobian approximation via the rank-1 Broyden formula:
+     *
+     * @f[
+     *   J^{-1}_{\text{new}} = J^{-1} +
+     *       \frac{(\Delta x - J^{-1}\,\Delta y)\,\Delta x^T J^{-1}}
+     *            {\Delta x^T J^{-1}\,\Delta y}
+     * @f]
+     *
+     * Call has_converged() after each call to decide whether to continue.
+     *
+     * @tparam F  Callable with the same signature as in initialize().
+     * @param fun The function whose zero is sought (same object as passed to initialize()).
+     * @return Always `true` (reserved for future error reporting).
+     */
     template <typename F>
-    bool iterate(F&& fun)
+    Status iterate(F&& fun)
     {
         /*
         UPDATE FORMULA
@@ -77,22 +131,24 @@ struct broyden : public zero_finding_method<Dim, broyden<Dim>> {
         delta_y = fun(_zero.asarray());
         update_y();
         update_inv_jac();
-        return true;
+        return Status::ok;
     }
 
-    bool has_converged()
+    Status has_converged()
     {
+        // converged if f(x) == 0
         if (this->is_zero(_residual, _zero)) {
             this->flag = Flag::residual_zero;
-            return true;
+            return Status::converged;
         }
 
+        // converged if no improvement (maybe should be a failure condition?)
         if (this->is_zero(delta_x, _zero)) {
             this->flag = Flag::delta_x_zero;
-            return true;
+            return Status::converged;
         }
 
-        return false;
+        return Status::ok;
     }
 
     std::array<double, Dim> residual() const

--- a/src/math/roots/multidim/newton.h
+++ b/src/math/roots/multidim/newton.h
@@ -8,13 +8,45 @@
 namespace root_multidim
 {
 
-/** @brief Newton's method.
+/**
+ * @brief Newton's method for finding vector-valued zeros of nonlinear systems.
  *
- *  @details
+ * This struct implements Newton's method given a function that provides the
+ * avoiding the full, dense Jacobian at every step. The linear system is
+ * solved using LU decomposition.
+ *
+ * @tparam Dim The dimension of the system (number of equations = number of unknowns).
+ *
+ * @par Usage Example
+ * @code
+ * // Define the system: find x such that f(x) = 0
+ * struct f {
+ * operator()(std::array<double, 2> x) -> std::array<double, 2> {
+ *     return { x[0]*x[0] + x[1] - 1.0,
+ *              x[0]      - x[1]*x[1] };
+ * }
+ *
+ * };
+ * using namespace root_multidim;
+ * // set solver with a max iterations, abs_tol, rel_rol
+ * newton<2> solver(100, 1e-5, 1e-5);
+ * std::array<double, 2> guess = { 0.5, 0.5 };
+ *
+ * result_t result = solver.solve(f, guess);
+ *
+ * @endcode
+ *
+ * @note Convergence may occur if the Jacobian is approximate, but
+ *       may be slow if the Jacobian is wrong. Use `broyden` or a Quasi-
+ *       Newton method if the Jacobian must be approximated numerically.
  */
 template <size_t Dim>
 struct newton : public zero_finding_method<Dim, newton<Dim>> {
     using zero_finding_method<Dim, newton<Dim>>::zero_finding_method;
+
+    friend class zero_finding_method<Dim, newton<Dim>>::zero_finding_method;
+
+   private:
     using vec_t = typename linalg::vector<double, Dim>;
     using mat_t = typename linalg::matrix<double, Dim, Dim>;
 
@@ -23,36 +55,36 @@ struct newton : public zero_finding_method<Dim, newton<Dim>> {
     vec_t y;
 
     template <typename F>
-    bool initialize(F&& fun, std::array<double, Dim> const& guess)
+    Status initialize(F&& fun, std::array<double, Dim> const& guess)
     {
         x = guess;
         y = fun(guess);
-        return true;
+        return Status::ok;
     }
 
     template <typename F>
-    bool iterate(F&& fun)
+    Status iterate(F&& fun)
     {
         linalg::LU<double, Dim> lu(fun.jacobian(x));
 
         auto sol = lu.solve(-1.0 * y);
         if (!sol) {
             this->flag = Flag::singular_matrix;
-            return false;
+            return Status::failed;
         }
         delta_x = sol.value();
         x += delta_x;
         y = fun(x.asarray());
-        return true;
+        return Status::ok;
     }
 
-    bool has_converged()
+    Status has_converged()
     {
         if (this->is_zero(y, x)) {
             this->flag = Flag::residual_zero;
-            return true;
+            return Status::converged;
         }
-        return false;
+        return Status::ok;
     }
 
     std::array<double, Dim> residual() const

--- a/src/math/roots/multidim/zeros.h
+++ b/src/math/roots/multidim/zeros.h
@@ -8,30 +8,97 @@
 #include "../../linalg/base.h"
 namespace root_multidim
 {
-// termination states
+/**
+ * @brief Termination status codes for zero-finding solvers.
+ *
+ * Returned inside result_t to indicate why iteration stopped.
+ * Successful termination is indicated by `residual_zero` or `delta_x_zero`;
+ * all other values indicate failure or a limit was reached.
+ */
 enum class Flag {
-    residual_zero,
-    delta_x_zero,
-    zero_is_nonfinite,
-    max_iterations,
-    function_is_nonfinite,
-    singular_matrix
+    residual_zero,          // f(x) == 0
+    delta_x_zero,           // current_x == last_x
+    zero_is_nonfinite,      // x = NaN, Inf, -Inf,
+    max_iterations,         //
+    function_is_nonfinite,  // f(x) = NaN, Inf, -Inf,
+    singular_matrix         // Esimtate
 };
 
+/**
+ * @brief Holds the outcome of a zero-finding solve.
+ *
+ * Aggregates the final estimate, residual, iteration count, and the
+ * reason iteration stopped.
+ *
+ * @tparam Dim Dimension of the system (number of equations = unknowns).
+ */
 template <size_t Dim>
 struct result_t {
     std::array<double, Dim> zero;
     std::array<double, Dim> residual;
     size_t iteration;
     Flag flag;
+    bool success;
 
     result_t(
         std::array<double, Dim> const& x,
         std::array<double, Dim> const& y,
         size_t i,
-        Flag f) : zero{x}, residual{y}, iteration{i}, flag{f} {}
+        Flag f,
+        bool success) : zero{x},
+                        residual{y},
+                        iteration{i},
+                        flag{f},
+                        success{success} {}
 };
 
+enum class Status {
+    ok,         // valid state, ok to continue iteration
+    invalid,    // invalid inputs, do not iterate
+    converged,  // successful termination
+    failed      // failed to converge
+};
+/**
+ * @brief CRTP base class for iterative zero-finding methods.
+ *
+ * Provides the outer solve loop, convergence tolerance helpers, and
+ * result packaging. Concrete methods (e.g. `broyden<Dim>`) derive from
+ * this class via the Curiously Recurring Template Pattern and must
+ * implement three member functions:
+ *
+ * | Function | Signature | Purpose |
+ * |---|---|---|
+ * | `initialize` | `bool initialize(F&& fun, Args&&... args)` | Set up state from the initial guess; return `false` to abort immediately. |
+ * | `iterate`    | `bool iterate(F&& fun)` | Advance the estimate by one step; return `false` to abort. |
+ * | `has_converged` | `bool has_converged()` | Return `true` (and set `this->flag`) when a stopping criterion is met. |
+ *
+ * The derived class must also expose `zero()` and `residual()` accessors
+ * returning `std::array<double, Dim>`.
+ *
+ * @tparam Dim    Dimension of the system.
+ * @tparam Method Concrete derived type (CRTP parameter).
+ *
+ * @par Typical usage (via a concrete method such as broyden)
+ * @code
+ * broyden<2> solver(200, 1e-10, 1e-10); // max_iter, abs_tol, rel_tol
+ *
+ * auto f = [](std::array<double, 2> x) -> std::array<double, 2> {
+ *     return { x[0]*x[0] + x[1] - 1.0,
+ *              x[0]      - x[1]*x[1] };
+ * };
+ *
+ * result_t<2> res = solver(f, std::array<double,2>{0.5, 0.5});
+ *
+ * if (res.success) {
+ *     // success — use res.zero
+ * }
+ * @endcode
+ *
+ * @note Tolerances apply dimension-aware norms: the vector overload of
+ *       `is_zero()` tests @f$ \|y\| < \varepsilon_\text{abs} +
+ *       \varepsilon_\text{rel}\|x\| @f$, so convergence criteria scale
+ *       consistently with problem size.
+ */
 template <size_t Dim, typename Method>
 struct zero_finding_method {
     zero_finding_method(size_t max_iter, double abs_tol, double rel_tol)
@@ -42,31 +109,65 @@ struct zero_finding_method {
     }
     zero_finding_method() = default;
 
-    size_t max_iterations = 100;
-    double _abs_tol = 1e-12;
-    double _rel_tol = 1e-12;
-    bool is_valid;
-    Flag flag;
+    // --- configuration --------------------------------------------------------
 
+    size_t max_iterations = 100;  ///< Maximum iterations before `Flag::max_iterations` is set.
+    double _abs_tol = 1e-12;      ///< Absolute tolerance used to test for `f(x) == 0`.
+    double _rel_tol = 1e-12;      ///< Relative tolerance used to test if `x == y`.
+
+    // --- state ----------------------------------------------------------------
+
+    Flag flag;                   ///< Reason for termination
+    Status status = Status::ok;  ///< Iteration status
+
+    // --- primary interface ----------------------------------------------------
+
+    /**
+     * @brief Runs the full solve loop.
+     *
+     * Calls `initialize`, then repeatedly calls `iterate` and
+     * `has_converged` until convergence, a failure signal, or
+     * `max_iterations` is reached.
+     *
+     * @tparam F    Callable representing the function whose zero is sought.
+     * @tparam Args Types of any additional arguments forwarded to `initialize`
+     *              (typically the initial guess).
+     * @param fun  The function f : R^Dim → R^Dim.
+     * @param args Additional arguments forwarded to `Method::initialize`.
+     * @return A `result_t<Dim>` describing the outcome.
+     */
     template <typename F, typename... Args>
     result_t<Dim> solve(F&& fun, Args&&... args)
     {
-        is_valid = static_cast<Method*>(this)->initialize(std::forward<F>(fun), std::forward<Args>(args)...);
+        // `initialize` internal state; forward method-specific arguments
+        // `initialize` checks if inputs satisfy requirements
+        status = static_cast<Method*>(this)->initialize(std::forward<F>(fun), std::forward<Args>(args)...);
+
+        // iteration loop;
+        // i counts the number of times `iterate` has been called
         for (size_t i = 0; i <= max_iterations; ++i) {
-            if (!is_valid) {
+            if (status != Status::ok) {
                 return make_result(i);
             }
 
-            is_valid = static_cast<Method*>(this)->iterate(std::forward<F>(fun));
+            status = static_cast<Method*>(this)->iterate(std::forward<F>(fun));
 
-            if (is_valid) {
-                is_valid = !(static_cast<Method*>(this)->has_converged());
+            if (status == Status::ok) {
+                status = static_cast<Method*>(this)->has_converged();
             }
         }
         flag = Flag::max_iterations;
         return make_result(max_iterations);
     }
 
+    /**
+     * @brief Convenience operator — equivalent to calling solve().
+     *
+     * Allows a solver object to be used as a callable:
+     * @code
+     *   result_t<N> res = solver(f, guess);
+     * @endcode
+     */
     template <typename F, typename... Args>
     inline result_t<Dim> operator()(F&& fun, Args&&... args)
     {
@@ -74,29 +175,68 @@ struct zero_finding_method {
     }
 
    protected:
+    // --- helpers available to derived classes ---------------------------------
+
+    /**
+     * @brief Packages the current solver state into a result_t.
+     * @param i Iteration index at the time of termination.
+     * @return  A `result_t` populated from the derived class's `zero()`,
+     *          `residual()`, and `this->flag`.
+     */
     result_t<Dim> make_result(size_t i)
     {
         return result_t<Dim>(
             static_cast<Method*>(this)->zero(),
             static_cast<Method*>(this)->residual(),
-            i, flag);
+            i,
+            flag,
+            status == Status::converged);
     }
-    // All methods require tolerance-based floating point number equality tests.
-    // Are two floating point numbers equal?
-    // Equality is lax if both `x` and `y` are big.
+
+    /**
+     * @brief Scalar approximate-equality test with mixed absolute/relative tolerance.
+     *
+     * Returns `true` when
+     * @f$ |x - y| \le \max(\varepsilon_\text{abs},\, \varepsilon_\text{rel} \cdot \min(|x|,|y|)) @f$.
+     *
+     * The tolerance is anchored to the *smaller* magnitude, so equality is
+     * easier to satisfy when both values are large (lax near infinity) and
+     * harder when both are near zero (tight near the origin).
+     *
+     * @param x First value.
+     * @param y Second value.
+     * @return `true` if x and y are considered equal under the configured tolerances.
+     */
     inline bool is_close(double x, double y) const
     {
         double norm = std::min(std::abs(x), std::abs(y));
         return std::abs(x - y) <= std::max(_abs_tol, _rel_tol * norm);
     }
 
-    // Is a floating point number zero?
+    /**
+     * @brief Scalar zero test.
+     * @param x Value to test.
+     * @return `true` if @f$ |x| \le \varepsilon_\text{abs} @f$.
+     */
     inline bool is_zero(double x) const
     {
         return std::abs(x) <= _abs_tol;
     }
 
-    // floating point errors can increase with dimension
+    /**
+     * @brief Vector zero test with dimension-aware mixed tolerance.
+     *
+     * Returns `true` when
+     * @f$ \|y\| < \varepsilon_\text{abs} + \varepsilon_\text{rel}\|x\| @f$.
+     *
+     * Using the norm of the current iterate `x` as the relative scale means
+     * the effective tolerance grows with the solution magnitude and does not
+     * tighten spuriously for large-valued problems.
+     *
+     * @param y Residual vector (the quantity being tested for smallness).
+     * @param x Current zero estimate (provides the relative scale).
+     * @return `true` if `y` is considered zero relative to `x`.
+     */
     inline bool is_zero(
         linalg::vector<double, Dim> const& y,
         linalg::vector<double, Dim> const& x) const
@@ -106,6 +246,11 @@ struct zero_finding_method {
         return std::sqrt(ysq) < _abs_tol + _rel_tol * std::sqrt(xsq);
     }
 
+    /**
+     * @brief Checks whether any component of a vector is NaN.
+     * @param x Vector to inspect.
+     * @return `true` if at least one component satisfies `std::isnan`.
+     */
     inline bool is_nan(linalg::vector<double, Dim> const& x) const
     {
         for (const double& v : x) {

--- a/src/math/roots/multidim/zeros.h
+++ b/src/math/roots/multidim/zeros.h
@@ -66,11 +66,22 @@ enum class Status {
  * this class via the Curiously Recurring Template Pattern and must
  * implement three member functions:
  *
- * | Function | Signature | Purpose |
- * |---|---|---|
- * | `initialize` | `bool initialize(F&& fun, Args&&... args)` | Set up state from the initial guess; return `false` to abort immediately. |
- * | `iterate`    | `bool iterate(F&& fun)` | Advance the estimate by one step; return `false` to abort. |
- * | `has_converged` | `bool has_converged()` | Return `true` (and set `this->flag`) when a stopping criterion is met. |
+ * | Function        | Signature                                    | Purpose                                                   |
+ * |-----------------|----------------------------------------------|-----------------------------------------------------------|
+ * | `initialize`    | `Status initialize(F&& fun, Args&&... args)` | Set up state from the initial guess                       |
+ * | `iterate`       | `Status iterate(F&& fun)`                    | Perform one iteration of the method (e.g., Newton update) |
+ * | `has_converged` | `Status has_converged()`                     | Check if stopping criteria is met.                        |
+ *
+ * Each function returns a `Status` enum class; these are status codes, that allow the method
+ * to communicate success or failure to this interface class.
+ *
+ * | `Status`            | Meaning                                                                            |
+ * |---------------------|------------------------------------------------------------------------------------|
+ * | `Status::ok`        | Iteration state is valid but has not converged. Ok to continue iteration           |
+ * | `Status::invalid`   | Iteration state is invalid; initial guess does not satisfy requirements of method  |
+ * | `Status::converged` | Iteration state meets convergence or tolerance criteria.                           |
+ * | `Status::failed`    | Iteration state has failed to converge (e.g., exceeded maximum iterations)         |
+ *
  *
  * The derived class must also expose `zero()` and `residual()` accessors
  * returning `std::array<double, Dim>`.


### PR DESCRIPTION
I spent an hour adding some documentation to the multidimensional root solving library code with a little from AI.  I also made a few minor changes. 

1. Root-solving methods should make all class methods that implement the method private, but make `zero_finding_method` a friend. 
2. Introduced a `Status` enum to replace the `is_valid` bool. I think the intended usage is clearer now, if someone wanted to introduce a new root-solving method. 

These changes could probably be done to the one-dimensional root solving library, but that's not a priority right now.