### PR TITLE
update all names to biocro style

### DIFF
--- a/src/math/quadrature/quad.h
+++ b/src/math/quadrature/quad.h
@@ -10,34 +10,34 @@
  *
  * All algorithms are templated on the return type `T` of the integrand, so
  * they work with `double` as well as any vector-space type that supports
- * `operator+=` and scalar `operator*` — in particular `PhotoCore::LeafAssim`,
+ * `operator+=` and scalar `operator*` — in particular `core::leaf_assim`,
  * which is used to compute canopy-integrated photosynthesis in `c3CanAC` and
  * `CanAC`.
  *
- * **Closed Newton-Cotes rules** evaluate the integrand at `Order * n + 1`
+ * **Closed Newton-Cotes rules** evaluate the integrand at `order * n + 1`
  * equally-spaced nodes including both endpoints.  All weights are absorbed
- * into `ClosedNewtonCotes<Order>` so the integration loop in
+ * into `closed_newton_cotes_rule<order>` so the integration loop in
  * `closed_newton_cotes` is identical for every rule.  Named convenience
- * wrappers (`trapezoid`, `simpsons_rule`, `three_eights_rule`, `booles_rule`)
+ * wrappers (`trapezoid`, `simpsons_rule`, `three_eighths_rule`, `booles_rule`)
  * forward to `closed_newton_cotes<1..4>`.  To add a new rule, specialise
- * `ClosedNewtonCotes<N>` with the pre-scaled `endpoint_weight` and `weights`
- * array (all weights already divided by the rule's scale factor).
+ * `closed_newton_cotes_rule<N>` with the pre-scaled `endpoint_weight` and
+ * `weights` array (all weights already divided by the rule's scale factor).
  *
- * **Gauss-Legendre rules** (`gauss_legendre<Order>`) place `Order` nodes per
+ * **Gauss-Legendre rules** (`gauss_legendre<order>`) place `order` nodes per
  * subinterval at positions that maximise the polynomial degree integrated
  * exactly.  Node positions and weights for each order are stored in
- * `GaussLegendreRule<Order>` specialisations (orders 2, 3, and 4 are
+ * `gauss_legendre_rule<order>` specialisations (orders 2, 3, and 4 are
  * provided).  The 2-point rule is the primary quadrature method used for the
  * canopy photosynthesis integral.
  *
- * **Usage** (canopy integral returning `PhotoCore::LeafAssim`):
+ * **Usage** (canopy integral returning `core::leaf_assim`):
  * @code{.cpp}
- * PhotoCore::LeafAssim canopy =
- *     quadrature::gauss_legendre<2, PhotoCore::LeafAssim>(integrand, 0.0, LAI, nlayers);
+ * core::leaf_assim canopy =
+ *     quadrature::gauss_legendre<2, core::leaf_assim>(integrand, 0.0, LAI, nlayers);
  * @endcode
  *
- * Zwillinger, Daniel (Ed.) CRC standard mathematical tables and formulae, 2012, 32. ed.
- *     pg 638-649 CRC Press: Boca Raton
+ * Zwillinger, Daniel (Ed.) CRC standard mathematical tables and formulae,
+ *     2012, 32. ed. pg 638-649 CRC Press: Boca Raton
  */
 namespace quadrature
 {
@@ -45,10 +45,10 @@ namespace quadrature
 /**
  * @brief Rule traits for composite closed Newton-Cotes quadrature.
  *
- * Closed Newton-Cotes rules evaluate the integrand at `Order * n + 1`
+ * Closed Newton-Cotes rules evaluate the integrand at `order * n + 1`
  * equally-spaced nodes across `[a, b]`, **including** both endpoints.  Within
- * each subinterval of width `dx = (b-a) / (Order * n)` the interior nodes
- * cycle through `Order` distinct weight classes indexed by `i % Order`.
+ * each subinterval of width `dx = (b-a) / (order * n)` the interior nodes
+ * cycle through `order` distinct weight classes indexed by `i % order`.
  * Shared interior nodes (where two adjacent panels meet) appear in both
  * panels and therefore carry double weight relative to a single-panel formula;
  * this doubling is pre-absorbed into `weights[0]`.
@@ -57,96 +57,96 @@ namespace quadrature
  * `closed_newton_cotes` only multiplies the accumulated sum by `dx` once.
  * `endpoint_weight` is the pre-scaled weight applied to `f(a)` and `f(b)`.
  *
- * | Order | Common name      | Unscaled endpoint | Unscaled interior weights    |
- * |-------|------------------|-------------------|------------------------------|
- * |   1   | Trapezoid        | 1/2               | 1                            |
- * |   2   | Simpson's        | 1/3               | 2/3, 4/3                     |
- * |   3   | Three-eighths    | 3/8               | 6/8, 9/8, 9/8                |
- * |   4   | Boole's          | 14/45             | 28/45, 64/45, 24/45, 64/45  |
+ * | Order | Common name      | Unscaled endpoint | Unscaled interior weights   |
+ * |-------|------------------|-------------------|-----------------------------|
+ * |   1   | Trapezoid        | 1/2               | 1                           |
+ * |   2   | Simpson's        | 1/3               | 2/3, 4/3                    |
+ * |   3   | Three-eighths    | 3/8               | 6/8, 9/8, 9/8               |
+ * |   4   | Boole's          | 14/45             | 28/45, 64/45, 24/45, 64/45 |
  *
- * To add a new rule, specialise `ClosedNewtonCotes<N>` with pre-scaled
+ * To add a new rule, specialise `closed_newton_cotes_rule<N>` with pre-scaled
  * `endpoint_weight` and `weights`, then call `closed_newton_cotes<N>`.
  */
-template <int Order>
-struct ClosedNewtonCotes;
+template <int order>
+struct closed_newton_cotes_rule;
 
 // Trapezoid rule: linear interpolation between endpoints.
 template <>
-struct ClosedNewtonCotes<1> {
+struct closed_newton_cotes_rule<1> {
     static constexpr double endpoint_weight = 0.5;
     static constexpr std::array<double, 1> weights = {1.0};
 };
 
 // Simpson's rule: exact for polynomials up to degree 3.
 template <>
-struct ClosedNewtonCotes<2> {
+struct closed_newton_cotes_rule<2> {
     static constexpr double endpoint_weight = 1.0 / 3.0;
     static constexpr std::array<double, 2> weights = {2.0 / 3.0, 4.0 / 3.0};
 };
 
 // Three-eighths rule: exact for polynomials up to degree 3.
 template <>
-struct ClosedNewtonCotes<3> {
+struct closed_newton_cotes_rule<3> {
     static constexpr double endpoint_weight = 3.0 / 8.0;
     static constexpr std::array<double, 3> weights = {6.0 / 8.0, 9.0 / 8.0, 9.0 / 8.0};
 };
 
 // Boole's rule: exact for polynomials up to degree 5.
 template <>
-struct ClosedNewtonCotes<4> {
-    static constexpr double endpoint_weight = 14.0 / 45.;
-    static constexpr std::array<double, 4> weights = {28.0 / 45.0, 64.0 / 45.0, 24.0 / 45, 64.0 / 45.0};
+struct closed_newton_cotes_rule<4> {
+    static constexpr double endpoint_weight = 14.0 / 45.0;
+    static constexpr std::array<double, 4> weights = {28.0 / 45.0, 64.0 / 45.0, 24.0 / 45.0, 64.0 / 45.0};
 };
 
-template <int Order, typename T = double, typename Integrand>
-T closed_newton_cotes(Integrand&& f, double a, double b, int n)
+template <int order, typename T = double, typename integrand>
+T closed_newton_cotes(integrand&& f, double a, double b, int n)
 {
-    using Rule = ClosedNewtonCotes<Order>;
-    int num = Order * n;
+    using rule = closed_newton_cotes_rule<order>;
+    int num = order * n;
     double const dx = (b - a) / num;
-    T result = Rule::endpoint_weight * (f(a) + f(b));
+    T result = rule::endpoint_weight * (f(a) + f(b));
     for (int i = 1; i < num; ++i) {
-        result += f(a + i * dx) * Rule::weights[i % Order];
+        result += f(a + i * dx) * rule::weights[i % order];
     }
     return result * dx;
 }
 
-template <typename T = double, typename Integrand>
-T trapezoid(Integrand&& f, double a, double b, int n)
+template <typename T = double, typename integrand>
+T trapezoid(integrand&& f, double a, double b, int n)
 {
-    return closed_newton_cotes<1, T>(std::forward<Integrand>(f), a, b, n);
+    return closed_newton_cotes<1, T>(std::forward<integrand>(f), a, b, n);
 }
 
-template <typename T = double, typename Integrand>
-T simpsons_rule(Integrand&& f, double a, double b, int n)
+template <typename T = double, typename integrand>
+T simpsons_rule(integrand&& f, double a, double b, int n)
 {
-    return closed_newton_cotes<2, T>(std::forward<Integrand>(f), a, b, n);
+    return closed_newton_cotes<2, T>(std::forward<integrand>(f), a, b, n);
 }
 
-template <typename T = double, typename Integrand>
-T three_eights_rule(Integrand&& f, double a, double b, int n)
+template <typename T = double, typename integrand>
+T three_eighths_rule(integrand&& f, double a, double b, int n)
 {
-    return closed_newton_cotes<3, T>(std::forward<Integrand>(f), a, b, n);
+    return closed_newton_cotes<3, T>(std::forward<integrand>(f), a, b, n);
 }
 
-template <typename T = double, typename Integrand>
-T booles_rule(Integrand&& f, double a, double b, int n)
+template <typename T = double, typename integrand>
+T booles_rule(integrand&& f, double a, double b, int n)
 {
-    return closed_newton_cotes<4, T>(std::forward<Integrand>(f), a, b, n);
+    return closed_newton_cotes<4, T>(std::forward<integrand>(f), a, b, n);
 }
 
 /**
  * @brief Rule traits for composite open Newton-Cotes quadrature.
  *
- * Open Newton-Cotes rules evaluate the integrand at `Order` equally-spaced
+ * Open Newton-Cotes rules evaluate the integrand at `order` equally-spaced
  * interior points of each subinterval, **excluding** both endpoints.  Within
  * a subinterval of width `dx`, the nodes are placed at
  *
- *   `x_j = a + i·dx + j·h`,  j = 1 … Order,  h = dx / (Order + 1)
+ *   `x_j = a + i·dx + j·h`,  j = 1 … order,  h = dx / (order + 1)
  *
- * so the two phantom endpoints at j = 0 and j = Order+1 are never evaluated.
- * Each `OpenNewtonCotes<Order>` specialisation stores `Order` pre-scaled
- * weights (already divided by the rule's scale factor h) so that
+ * so the two phantom endpoints at j = 0 and j = order+1 are never evaluated.
+ * Each `open_newton_cotes_rule<order>` specialisation stores `order`
+ * pre-scaled weights (already divided by the rule's scale factor h) so that
  * `open_newton_cotes` multiplies the accumulated sum by `h` exactly once.
  *
  * | Order | Common name    | Unscaled weights    |
@@ -155,57 +155,57 @@ T booles_rule(Integrand&& f, double a, double b, int n)
  * |   2   | Two-point open | 3/2, 3/2            |
  * |   3   | Milne's rule   | 8/3, −4/3, 8/3      |
  *
- * To add a new rule, specialise `OpenNewtonCotes<N>` with pre-scaled weights
- * and call `open_newton_cotes<N>(f, a, b, n)`.
+ * To add a new rule, specialise `open_newton_cotes_rule<N>` with pre-scaled
+ * weights and call `open_newton_cotes<N>(f, a, b, n)`.
  */
-template <int Order>
-struct OpenNewtonCotes;
+template <int order>
+struct open_newton_cotes_rule;
 
 // Midpoint rule: single node at the centre of each subinterval.
 template <>
-struct OpenNewtonCotes<1> {
+struct open_newton_cotes_rule<1> {
     static constexpr std::array<double, 1> weights = {2.0};
 };
 
 // Two-point open rule: nodes at 1/3 and 2/3 of each subinterval.
 template <>
-struct OpenNewtonCotes<2> {
+struct open_newton_cotes_rule<2> {
     static constexpr std::array<double, 2> weights = {3.0 / 2.0, 3.0 / 2.0};
 };
 
 // Milne's rule: nodes at 1/4, 1/2, and 3/4 of each subinterval.
 // Note the negative centre weight — this rule is not positive-definite.
 template <>
-struct OpenNewtonCotes<3> {
+struct open_newton_cotes_rule<3> {
     static constexpr std::array<double, 3> weights = {8.0 / 3.0, -4.0 / 3.0, 8.0 / 3.0};
 };
 
-template <int Order, typename T = double, typename Integrand>
-T open_newton_cotes(Integrand&& f, double a, double b, int n)
+template <int order, typename T = double, typename integrand>
+T open_newton_cotes(integrand&& f, double a, double b, int n)
 {
-    using Rule = OpenNewtonCotes<Order>;
+    using rule = open_newton_cotes_rule<order>;
     double const dx = (b - a) / n;
-    double const h = dx / (Order + 1);
+    double const h = dx / (order + 1);
     T result{};
     for (int i = 0; i < n; ++i) {
-        for (int j = 0; j < Order; ++j)
-            result += f(a + i * dx + (j + 1) * h) * Rule::weights[j];
+        for (int j = 0; j < order; ++j)
+            result += f(a + i * dx + (j + 1) * h) * rule::weights[j];
     }
     return result * h;
 }
 
-template <typename T = double, typename Integrand>
-T midpoint_rule(Integrand&& f, double a, double b, int n)
+template <typename T = double, typename integrand>
+T midpoint_rule(integrand&& f, double a, double b, int n)
 {
-    return open_newton_cotes<1, T>(std::forward<Integrand>(f), a, b, n);
+    return open_newton_cotes<1, T>(std::forward<integrand>(f), a, b, n);
 }
 
 /**
  * @brief Rule traits for composite Gauss-Legendre quadrature.
  *
- * Gauss-Legendre rules place `Order` nodes per subinterval at positions
+ * Gauss-Legendre rules place `order` nodes per subinterval at positions
  * chosen to maximise the degree of polynomial integrated exactly: an
- * `Order`-point rule is exact for polynomials up to degree `2*Order - 1`.
+ * `order`-point rule is exact for polynomials up to degree `2*order - 1`.
  * Unlike Newton-Cotes rules, the nodes are **not** equally spaced and never
  * coincide with the subinterval endpoints.
  *
@@ -222,30 +222,30 @@ T midpoint_rule(Integrand&& f, double a, double b, int n)
  * |   3   | 5                  | 0, ±√(3/5)                          |
  * |   4   | 7                  | ±0.339…, ±0.861…                    |
  *
- * To add a new order, specialise `GaussLegendreRule<N>` with the standard
+ * To add a new order, specialise `gauss_legendre_rule<N>` with the standard
  * Gauss-Legendre abscissae and weights on `[-1, 1]` (available in standard
  * references or computed via eigenvalue methods).
  */
-template <int Order>
-struct GaussLegendreRule;  // leave undefined; only specializations are valid
+template <int order>
+struct gauss_legendre_rule;  // leave undefined; only specialisations are valid
 
 // 2-point rule: exact for polynomials up to degree 3.
 template <>
-struct GaussLegendreRule<2> {
+struct gauss_legendre_rule<2> {
     static constexpr std::array<double, 2> abscissa = {-0.5773502691896258, 0.5773502691896258};
     static constexpr std::array<double, 2> weights = {1.0, 1.0};
 };
 
 // 3-point rule: exact for polynomials up to degree 5.
 template <>
-struct GaussLegendreRule<3> {
+struct gauss_legendre_rule<3> {
     static constexpr std::array<double, 3> abscissa = {-0.7745966692414834, 0.0, 0.7745966692414834};
     static constexpr std::array<double, 3> weights = {5.0 / 9.0, 8.0 / 9.0, 5.0 / 9.0};
 };
 
 // 4-point rule: exact for polynomials up to degree 7.
 template <>
-struct GaussLegendreRule<4> {
+struct gauss_legendre_rule<4> {
     static constexpr std::array<double, 4> abscissa = {
         -0.8611363115940526,
         -0.3399810435848563,
@@ -255,23 +255,22 @@ struct GaussLegendreRule<4> {
         0.34785484513745385,
         0.6521451548625461,
         0.6521451548625461,
-        0.34785484513745385,
-    };
+        0.34785484513745385};
 };
 
-template <int Order, typename T = double, typename Integrand>
-T gauss_legendre(Integrand&& f, double a, double b, int n)
+template <int order, typename T = double, typename integrand>
+T gauss_legendre(integrand&& f, double a, double b, int n)
 {
-    using Rule = GaussLegendreRule<Order>;
+    using rule = gauss_legendre_rule<order>;
     double const dx = (b - a) / n;
     T result{};
     for (int i = 0; i < n; ++i) {
         double const mid = a + (i + 0.5) * dx;
-        for (int j = 0; j < Order; ++j) {
-            result += f(mid + 0.5 * dx * Rule::abscissa[j]) * Rule::weights[j];
+        for (int j = 0; j < order; ++j) {
+            result += f(mid + 0.5 * dx * rule::abscissa[j]) * rule::weights[j];
         }
     }
-    return result * (dx * 0.5);
+    return result * (0.5 * dx);
 }
 
 }  // namespace quadrature

--- a/src/module_library/CanAC.cpp
+++ b/src/module_library/CanAC.cpp
@@ -3,8 +3,8 @@
 #include "../math/quadrature/quad.h"           // for quadrature::gauss_legendre_2
 #include "../math/roots/onedim/fixed_point.h"  // for fixed_point
 #include "c4photo.h"                           // for c4photoC
-#include "core/atmosphere_light_scattering.h"  // for PhotoCore::AtmosphereLightScattering
-#include "core/photosynthesis.h"               // for PhotoCore::LeafAssim, CanopyIntegrand
+#include "core/atmosphere_light_scattering.h"  // for core::atmosphere_light_scattering
+#include "core/photosynthesis.h"               // for core::leaf_assim, CanopyIntegrand
 #include "leaf_energy_balance.h"               // for leaf_energy_balance
 #include "respiration.h"                       // for growth_resp
 #include "CanAC.h"
@@ -51,7 +51,7 @@ canopy_photosynthesis_outputs CanAC(
     int nlayers                  // dimensionless
 )
 {
-    PhotoCore::AtmosphereLightScattering const light_model(
+    core::atmosphere_light_scattering const light_model(
         cosine_zenith_angle,
         atmospheric_pressure,
         atmospheric_transmittance,
@@ -63,7 +63,7 @@ canopy_photosynthesis_outputs CanAC(
     double const q_diff = light_model.diffuse_fraction * solarR;  // micromol / m^2 / s
 
     // heightf = 1 since canopy height is not used anywhere in this function.
-    PhotoCore::CanopyLight const canopy_light(
+    core::canopy_light const light_dist(
         q_dir,
         q_diff,
         chil,
@@ -78,16 +78,15 @@ canopy_photosynthesis_outputs CanAC(
         par_energy_content,
         par_energy_fraction);
 
-
     using namespace root_finding;
 
     // Set convergence criteria
     root_finding::fixed_point solver(50, 1e-3, 1e-3);
 
-    // Leaf-level photosynthesis function for use with PhotoCore::CanopyIntegrand.
+    // Leaf-level photosynthesis function for use with core::canopy_integrand.
     // Solves the coupled stomatal conductance / energy balance system for a
     // single leaf class (sunlit or shaded) and returns a LeafAssim summary.
-    auto leaf_photo = [&](double i_ppfd, double j_shortwave, double layer_wind_speed, double layer_leafN) -> PhotoCore::LeafAssim {
+    auto leaf_photo = [&](double i_ppfd, double j_shortwave, double layer_wind_speed, double layer_leafN) -> core::leaf_assim {
         double eff_Vcmax = Vcmax_at_25;
         double eff_Alpha = Alpha;
         double eff_RL = RL_at_25;
@@ -137,7 +136,6 @@ canopy_photosynthesis_outputs CanAC(
             return photo.Gs;
         };
 
-
         result_t result = solver.solve(gs_func, gsw_estimate);
 
         if (!is_successful(result.flag)) {
@@ -149,7 +147,7 @@ canopy_photosynthesis_outputs CanAC(
         // mmol / m^2 / s -> Mg / ha / hr: (3600 s/hr)(1e-3 mol/mmol)(1e-3 Mg/kg)(1e4 m^2/ha)
         double constexpr cf2 = physical_constants::molar_mass_of_water * 36;
 
-        return PhotoCore::LeafAssim{
+        return core::leaf_assim{
             /* .assim = */ photo.Assim,
             /* .stomatal_vapor_conductance = */ photo.Gs,
             /* .penman = */ et.EPenman,
@@ -160,10 +158,10 @@ canopy_photosynthesis_outputs CanAC(
             /* .transpiration = */ et.TransR * cf2};
     };
 
-    PhotoCore::CanopyIntegrand<decltype(leaf_photo), false> canopy_integrand(leaf_photo, canopy_light, kpLN, leafN, WindSpeed);
+    core::canopy_integrand<decltype(leaf_photo), false> canopy_integrand(leaf_photo, light_dist, kpLN, leafN, WindSpeed);
     // use `quadrature::midpoint_rule` for previous behavior
-    PhotoCore::LeafAssim const canopy =
-        quadrature::gauss_legendre<2, PhotoCore::LeafAssim>(canopy_integrand, 0.0, LAI, nlayers);
+    core::leaf_assim const canopy =
+        quadrature::gauss_legendre<2, core::leaf_assim>(canopy_integrand, 0.0, LAI, nlayers);
 
     double const whole_plant_gr =
         growth_resp(canopy.assim, growth_respiration_fraction);  // micromol / m^2 / s

--- a/src/module_library/c3CanAC.cpp
+++ b/src/module_library/c3CanAC.cpp
@@ -2,9 +2,9 @@
 #include "../math/quadrature/quad.h"           // for quadrature::gauss_legendre_2
 #include "../math/roots/onedim/fixed_point.h"  // for fixed_point
 #include "c3photo.h"                           // for c3photoC
-#include "core/photosynthesis.h"               // for PhotoCore::LeafAssim, CanopyIntegrand
+#include "core/photosynthesis.h"               // for core::leaf_assim, CanopyIntegrand
 #include "leaf_energy_balance.h"               // for leaf_energy_balance
-#include "core/atmosphere_light_scattering.h"  // for PhotoCore::AtmosphereLightScattering
+#include "core/atmosphere_light_scattering.h"  // for core::atmosphere_light_scattering
 #include "respiration.h"                       // for growth_resp
 #include "c3CanAC.h"
 
@@ -58,7 +58,7 @@ canopy_photosynthesis_outputs c3CanAC(
     int const nlayers                  // dimensionless
 )
 {
-    PhotoCore::AtmosphereLightScattering const light_model(
+    core::atmosphere_light_scattering const light_model(
         cosine_zenith_angle,
         atmospheric_pressure,
         atmospheric_transmittance,
@@ -69,7 +69,7 @@ canopy_photosynthesis_outputs c3CanAC(
     double const q_dir = light_model.direct_fraction * solarR;    // micromol / m^2 / s
     double const q_diff = light_model.diffuse_fraction * solarR;  // micromol / m^2 / s
 
-    PhotoCore::CanopyLight canopy_light_model(
+    core::canopy_light light_dist(
         q_dir,
         q_diff,  // micromol / m^2 / s
         chil,
@@ -89,10 +89,10 @@ canopy_photosynthesis_outputs c3CanAC(
     // Set convergence criteria
     root_finding::fixed_point solver(50, 1e-3, 1e-3);
 
-    // Leaf-level photosynthesis function for use with PhotoCore::CanopyIntegrand.
+    // Leaf-level photosynthesis function for use with core::canopy_integrand.
     // Solves the coupled stomatal conductance / energy balance system for a
     // single leaf class (sunlit or shaded) and returns a LeafAssim summary.
-    auto leaf_photo = [&](double iabs, double j_shortwave, double layer_wind_speed, double layer_leafN) -> PhotoCore::LeafAssim {
+    auto leaf_photo = [&](double iabs, double j_shortwave, double layer_wind_speed, double layer_leafN) -> core::leaf_assim {
         double const effective_Vcmax = (lnfun != 0) ? layer_leafN * lnb1 + lnb0 : Vcmax_at_25;
         double constexpr gbw_guess = 1.2;  // mol / m^2 / s
 
@@ -121,7 +121,7 @@ canopy_photosynthesis_outputs c3CanAC(
                 current_gs,
                 layer_wind_speed);
 
-                double leaf_temperature_dir =
+            double leaf_temperature_dir =
                 ambient_temperature + et.Deltat;  // degrees C
 
             photo = c3photoC(
@@ -145,7 +145,7 @@ canopy_photosynthesis_outputs c3CanAC(
         // mmol / m^2 / s -> Mg / ha / hr: (3600 s/hr)(1e-3 mol/mmol)(1e-3 Mg/kg)(1e4 m^2/ha)
         double constexpr cf2 = physical_constants::molar_mass_of_water * 36;
 
-        return PhotoCore::LeafAssim{
+        return core::leaf_assim{
             /* .assim = */ photo.Assim,
             /* .stomatal_vapor_conductance = */ photo.Gs,
             /* .penman = */ et.EPenman,
@@ -156,9 +156,9 @@ canopy_photosynthesis_outputs c3CanAC(
             /* .transpiration = */ et.TransR * cf2};
     };
 
-    PhotoCore::CanopyIntegrand integrand(
+    core::canopy_integrand integrand(
         leaf_photo,
-        canopy_light_model,
+        light_dist,
         kpLN,
         leafN,     // micromol / m^2 / s
         WindSpeed  // m / s
@@ -166,8 +166,8 @@ canopy_photosynthesis_outputs c3CanAC(
     );
 
     // use `quadrature::midpoint_rule` for previous behavior
-    PhotoCore::LeafAssim const canopy =
-        quadrature::gauss_legendre<2, PhotoCore::LeafAssim>(integrand, 0.0, LAI, nlayers);
+    core::leaf_assim const canopy =
+        quadrature::gauss_legendre<2, core::leaf_assim>(integrand, 0.0, LAI, nlayers);
 
     // Calculate the rate of whole-plant growth respiration
     double const whole_plant_gr =

--- a/src/module_library/canopy_light_distribution.h
+++ b/src/module_library/canopy_light_distribution.h
@@ -22,7 +22,7 @@ class canopy_light_distribution : public direct_module
           atmospheric_scattering{get_input(input_quantities, "atmospheric_scattering")},
           chil{get_input(input_quantities, "chil")},
           cosine_zenith_angle{get_input(input_quantities, "cosine_zenith_angle")},
-          cumulative_lai{get_input(input_quantities, "cumulative_lai")},  
+          cumulative_lai{get_input(input_quantities, "cumulative_lai")},
           heightf{get_input(input_quantities, "heightf")},
           k_diffuse{get_input(input_quantities, "k_diffuse")},
           lai{get_input(input_quantities, "lai")},
@@ -33,43 +33,43 @@ class canopy_light_distribution : public direct_module
           par_energy_content{get_input(input_quantities, "par_energy_content")},
           par_energy_fraction{get_input(input_quantities, "par_energy_fraction")},
           solar{get_input(input_quantities, "solar")},
-          
-          // Get pointers to output quantities
-     height_op{get_op(output_quantities, "height")},
-     sunlit_fraction_op{get_op(output_quantities, "sunlit_fraction")},
-     sunlit_absorbed_ppfd_op{get_op(output_quantities, "sunlit_absorbed_ppfd")},
-     sunlit_absorbed_shortwave_op{get_op(output_quantities, "sunlit_absorbed_shortwave")},
-     sunlit_incident_nir_op{get_op(output_quantities, "sunlit_incident_nir")},
-     sunlit_incident_ppfd_op{get_op(output_quantities, "sunlit_incident_ppfd")},
-     shaded_fraction_op{get_op(output_quantities, "shaded_fraction")},
-     shaded_absorbed_ppfd_op{get_op(output_quantities, "shaded_absorbed_ppfd")},
-     shaded_absorbed_shortwave_op{get_op(output_quantities, "shaded_absorbed_shortwave")},
-     shaded_incident_nir_op{get_op(output_quantities, "shaded_incident_nir")},
-     shaded_incident_ppfd_op{get_op(output_quantities, "shaded_incident_ppfd")}
 
+          // Get pointers to output quantities
+          height_op{get_op(output_quantities, "height")},
+          sunlit_fraction_op{get_op(output_quantities, "sunlit_fraction")},
+          sunlit_absorbed_ppfd_op{get_op(output_quantities, "sunlit_absorbed_ppfd")},
+          sunlit_absorbed_shortwave_op{get_op(output_quantities, "sunlit_absorbed_shortwave")},
+          sunlit_incident_nir_op{get_op(output_quantities, "sunlit_incident_nir")},
+          sunlit_incident_ppfd_op{get_op(output_quantities, "sunlit_incident_ppfd")},
+          shaded_fraction_op{get_op(output_quantities, "shaded_fraction")},
+          shaded_absorbed_ppfd_op{get_op(output_quantities, "shaded_absorbed_ppfd")},
+          shaded_absorbed_shortwave_op{get_op(output_quantities, "shaded_absorbed_shortwave")},
+          shaded_incident_nir_op{get_op(output_quantities, "shaded_incident_nir")},
+          shaded_incident_ppfd_op{get_op(output_quantities, "shaded_incident_ppfd")}
     {
     }
+
     static string_vector get_inputs() {
         return {
-                    "atmospheric_pressure",         // Pa
-                    "atmospheric_scattering",       // dimensionless
-                    "atmospheric_transmittance",    // dimensionless
-                    "chil",                         // dimensionless
-                    "cosine_zenith_angle",          // dimensionless
-                    "cumulative_lai",
-                    "heightf",                      // m^(-1)
-                    "k_diffuse",                    // dimensionless
-                    "lai",                     // dimensionless
-                    "leaf_reflectance_nir",    // dimensionless
-                    "leaf_reflectance_par",    // dimensionless
-                    "leaf_transmittance_nir",  // dimensionless
-                    "leaf_transmittance_par",  // dimensionless
-                    "par_energy_content",   // J / micromol
-                    "par_energy_fraction",  // dimensionless
-                    "solar"                // micromol / m^2 / s
-                    
-                    };        
+            "atmospheric_pressure",         // Pa
+            "atmospheric_scattering",       // dimensionless
+            "atmospheric_transmittance",    // dimensionless
+            "chil",                         // dimensionless from m^2 / m^2
+            "cosine_zenith_angle",          // dimensionless
+            "cumulative_lai",               // dimensionless from m^2 leaf / m^2 ground
+            "heightf",                      // m^-1
+            "k_diffuse",                    // dimensionless
+            "lai",                          // dimensionless from m^2 / m^2
+            "leaf_reflectance_nir",         // dimensionless
+            "leaf_reflectance_par",         // dimensionless
+            "leaf_transmittance_nir",       // dimensionless
+            "leaf_transmittance_par",       // dimensionless
+            "par_energy_content",           // J / micromol
+            "par_energy_fraction",          // dimensionless
+            "solar"                         // micromol / m^2 / s
+        };
     }
+
     static string_vector get_outputs() {
         return {
             "height",
@@ -82,29 +82,31 @@ class canopy_light_distribution : public direct_module
             "shaded_absorbed_ppfd",
             "shaded_absorbed_shortwave",
             "shaded_incident_nir",
-            "shaded_incident_ppfd"  
+            "shaded_incident_ppfd"
         };
     }
+
     static std::string get_name() { return "canopy_light_distribution"; }
 
    private:
     // References to input quantities
-    double const& atmospheric_pressure;
-    double const& atmospheric_transmittance;
-    double const& atmospheric_scattering;
-    double const& chil;                    // dimensionless from m^2 / m^2
-    double const& cosine_zenith_angle;     // dimensionless
-    double const& cumulative_lai;
-    double const& heightf;                 // m^-1 from m^2 leaf / m^2 ground / m height
-    double const& k_diffuse;               // dimensionless
-    double const& lai;                     // dimensionless from m^2 / m^2
-    double const& leaf_reflectance_nir;    // dimensionless
-    double const& leaf_reflectance_par;    // dimensionless
-    double const& leaf_transmittance_nir;  // dimensionless
-    double const& leaf_transmittance_par;  // dimensionless
-    double const& par_energy_content;     // J / micromol
+    double const& atmospheric_pressure;     // Pa
+    double const& atmospheric_transmittance;  // dimensionless
+    double const& atmospheric_scattering;   // dimensionless
+    double const& chil;                     // dimensionless from m^2 / m^2
+    double const& cosine_zenith_angle;      // dimensionless
+    double const& cumulative_lai;           // dimensionless from m^2 leaf / m^2 ground
+    double const& heightf;                  // m^-1 from m^2 leaf / m^2 ground / m height
+    double const& k_diffuse;                // dimensionless
+    double const& lai;                      // dimensionless from m^2 / m^2
+    double const& leaf_reflectance_nir;     // dimensionless
+    double const& leaf_reflectance_par;     // dimensionless
+    double const& leaf_transmittance_nir;   // dimensionless
+    double const& leaf_transmittance_par;   // dimensionless
+    double const& par_energy_content;       // J / micromol
     double const& par_energy_fraction;      // dimensionless
-    double const& solar;
+    double const& solar;                    // micromol / m^2 / s
+
     // Pointers to output quantities
     double* height_op;
     double* sunlit_fraction_op;
@@ -118,31 +120,28 @@ class canopy_light_distribution : public direct_module
     double* shaded_incident_nir_op;
     double* shaded_incident_ppfd_op;
 
-
-    // Main operation
     void do_operation() const {
-        PhotoCore::AtmosphereLightScattering light_scattering(
-             cosine_zenith_angle,
-             atmospheric_pressure,
-             atmospheric_transmittance,
-             atmospheric_scattering);
-        PhotoCore::CanopyLight light_model = PhotoCore::CanopyLight::from_solar(
+        core::atmosphere_light_scattering light_scattering(
+            cosine_zenith_angle,
+            atmospheric_pressure,
+            atmospheric_transmittance,
+            atmospheric_scattering);
+        core::canopy_light light_model = core::canopy_light::from_solar(
             solar,
             light_scattering.direct_fraction,
             light_scattering.diffuse_fraction,
             chil,
-            cosine_zenith_angle,     // dimensionless
-            heightf,                 // m^-1 from m^2 leaf / m^2 ground / m height
-            k_diffuse,               // dimensionless
-            lai,                     // dimensionless from m^2 / m^2
-            leaf_reflectance_nir,    // dimensionless
-            leaf_reflectance_par,    // dimensionless
-            leaf_transmittance_nir,  // dimensionless
-            leaf_transmittance_par,  // dimensionless
-            par_energy_content,      // J / micromol
-            par_energy_fraction      // dimensionless
-        );
-        PhotoCore::LightProfile profile = light_model.get_light_profile(cumulative_lai);
+            cosine_zenith_angle,
+            heightf,
+            k_diffuse,
+            lai,
+            leaf_reflectance_nir,
+            leaf_reflectance_par,
+            leaf_transmittance_nir,
+            leaf_transmittance_par,
+            par_energy_content,
+            par_energy_fraction);
+        core::light_profile profile = light_model.get_light_profile(cumulative_lai);
 
         update(height_op, profile.height);
         update(sunlit_fraction_op, profile.sunlit.fraction);
@@ -155,13 +154,8 @@ class canopy_light_distribution : public direct_module
         update(shaded_absorbed_shortwave_op, profile.shaded.absorbed_shortwave);
         update(shaded_incident_nir_op, profile.shaded.incident_nir);
         update(shaded_incident_ppfd_op, profile.shaded.incident_ppfd);
-
     }
-
-    
 };
 
-
-
-}
+}  // namespace standardBML
 #endif

--- a/src/module_library/core/atmosphere_light_scattering.cpp
+++ b/src/module_library/core/atmosphere_light_scattering.cpp
@@ -2,7 +2,7 @@
 #include "../framework/constants.h"  // for atmospheric_pressure_at_sea_level
 #include <cmath>
 using physical_constants::atmospheric_pressure_at_sea_level;
-namespace PhotoCore {
+namespace core {
 /**
  * @brief Calculates the "light macro environment"; in other words, the amount
  * of sunlight scattered out of the direct beam by the atmosphere.
@@ -53,7 +53,7 @@ namespace PhotoCore {
  * @return A structure containing values of the transmittances and fractions of
  *         direct and diffuse light just above the canopy.
  */
-AtmosphereLightScattering::AtmosphereLightScattering(
+atmosphere_light_scattering::atmosphere_light_scattering(
     double cosine_zenith_angle,        // dimensionless
     double atmospheric_pressure,       // Pa
     double atmospheric_transmittance,  // dimensionless
@@ -94,8 +94,6 @@ AtmosphereLightScattering::AtmosphereLightScattering(
 
     // The remaining irradiance is diffuse (dimensionless).
     diffuse_fraction = 1.0 - direct_fraction;
-
-    
 }
 
-}
+}  // namespace core

--- a/src/module_library/core/atmosphere_light_scattering.h
+++ b/src/module_library/core/atmosphere_light_scattering.h
@@ -6,7 +6,7 @@
  * @brief Models the partitioning of incoming solar radiation into direct and
  * diffuse components by the atmosphere.
  *
- * `AtmosphereLightScattering` is a value struct whose constructor computes
+ * `atmosphere_light_scattering` is a value struct whose constructor computes
  * the direct and diffuse fractions of solar radiation at the Earth's surface
  * given the solar zenith angle, local atmospheric pressure, and two empirical
  * scattering parameters.  The model is based on Chapter 11 of Campbell &
@@ -15,22 +15,21 @@
  * In the canopy photosynthesis pipeline this is typically the first step:
  * `direct_fraction` and `diffuse_fraction` are multiplied by a measured
  * total solar flux (`solarR`) to obtain the beam and diffuse PPFD values
- * used to construct a `PhotoCore::CanopyLight` object.
+ * used to construct a `core::canopy_light` object.
  */
-namespace PhotoCore {
-struct AtmosphereLightScattering {
+namespace core {
+struct atmosphere_light_scattering {
     double direct_transmittance;   //!< Atmospheric transmittance to direct radiation (dimensionless)
     double diffuse_transmittance;  //!< Atmospheric transmittance to diffuse radiation (dimensionless)
     double direct_fraction;        //!< Fraction of direct irradiance at the Earth's surface (dimensionless)
     double diffuse_fraction;       //!< Fraction of diffuse irradiance at the Earth's surface (dimensionless)
-    
-    
-    AtmosphereLightScattering(
+
+    atmosphere_light_scattering(
         double cosine_zenith_angle,
         double atmospheric_pressure,
         double atmospheric_transmittance,
         double atmospheric_scattering);
 };
 
-}
+}  // namespace core
 #endif

--- a/src/module_library/core/canopy_light_distribution.cpp
+++ b/src/module_library/core/canopy_light_distribution.cpp
@@ -2,7 +2,7 @@
 #include <stdexcept>  // std::out_of_range
 
 #include "canopy_light_distribution.h"
-namespace PhotoCore {
+namespace core {
 /**
  *  @brief Computes absorbed light from incident light for a thin layer of
  *  material.
@@ -408,7 +408,7 @@ double shaded_radiation(
  *          the canopy, including several photon flux densities and
  *          the relative fractions of shaded and sunlit leaves
  */
-CanopyLight::CanopyLight(
+canopy_light::canopy_light(
     double ambient_ppfd_beam,
     double ambient_ppfd_diffuse,
     double chil,                    // dimensionless from m^2 / m^2
@@ -483,11 +483,12 @@ CanopyLight::CanopyLight(
     // sunlit; this corresponds to the case where cosine_zenith_angle is close
     // to or below zero.
     canopy_direct_transmission_fraction =
-        cosine_zenith_angle <= 1E-10 ? 0.0 : exp(-k_direct * lai);  // dimensionless
+        cosine_zenith_angle <= 1e-10 ? 0.0 : exp(-k_direct * lai);  // dimensionless
 
     // Calculate the ambient direct PPFD through a surface parallel to the ground
     ambient_ppfd_beam_ground = ambient_ppfd_beam * cosine_zenith_angle;  // micromol / (m^2 ground) / s
-                                                                         // Calculate related NIR energy fluxes
+
+    // Calculate related NIR energy fluxes
     ambient_nir_beam = nir_from_ppfd(
         ambient_ppfd_beam, par_energy_content, par_energy_fraction);  // J / (m^2 beam) / s
 
@@ -499,7 +500,7 @@ CanopyLight::CanopyLight(
     // For values of cosine_zenith_angle close to or less than 0, in place
     // of the calculations above, we want to use the limits of the above
     // expressions as cosine_zenith_angle approaches 0 from the right:
-    if (cosine_zenith_angle <= 1E-10) {
+    if (cosine_zenith_angle <= 1e-10) {
         ambient_ppfd_beam_leaf = ambient_ppfd_beam / k1;
         ambient_nir_beam_leaf = ambient_nir_beam / k1;
     } else {
@@ -510,14 +511,13 @@ CanopyLight::CanopyLight(
     }
 }
 
-LightProfile CanopyLight::get_light_profile(double cumulative_lai) const
+light_profile canopy_light::get_light_profile(double cumulative_lai) const
 {
-    
-    LightProfile profile;
+    light_profile profile;
     // For values of cosine_zenith_angle close to or less than 0, in place
     // of the calculations above, we want to use the limits of the above
     // expressions as cosine_zenith_angle approaches 0 from the right:
-    if (cosine_zenith_angle <= 1E-10) {
+    if (cosine_zenith_angle <= 1e-10) {
         profile.shaded.incident_ppfd = ambient_ppfd_diffuse * std::exp(-k_diffuse * cumulative_lai);
         profile.shaded.incident_nir = ambient_nir_diffuse * std::exp(-k_diffuse * cumulative_lai);
         // Calculate the fraction of sunlit and shaded leaves in this canopy
@@ -582,7 +582,7 @@ LightProfile CanopyLight::get_light_profile(double cumulative_lai) const
 }
 
 
-CanopyLight CanopyLight::from_solar(
+canopy_light canopy_light::from_solar(
         double solarR,
         double direct_fraction,
         double diffuse_fraction,
@@ -599,8 +599,8 @@ CanopyLight CanopyLight::from_solar(
         double par_energy_fraction      // dimensionless
     ) {
         double ambient_ppfd_beam = direct_fraction * solarR;
-        double ambient_ppfd_diffuse = diffuse_fraction * solarR; 
-    return CanopyLight(
+        double ambient_ppfd_diffuse = diffuse_fraction * solarR;
+    return canopy_light(
          ambient_ppfd_beam,
          ambient_ppfd_diffuse,
          chil,                    // dimensionless from m^2 / m^2
@@ -613,8 +613,7 @@ CanopyLight CanopyLight::from_solar(
          leaf_transmittance_nir,  // dimensionless
          leaf_transmittance_par,  // dimensionless
          par_energy_content,      // J / micromol
-         par_energy_fraction);      // dimensionless
-    
+         par_energy_fraction);  // dimensionless
 }
-    
-}
+
+}  // namespace core

--- a/src/module_library/core/canopy_light_distribution.h
+++ b/src/module_library/core/canopy_light_distribution.h
@@ -14,28 +14,28 @@
  *
  * **Key types:**
  *
- * - `CanopyLight` — the main model object.  Constructed once from canopy
+ * - `canopy_light` — the main model object.  Constructed once from canopy
  *   structural and optical parameters (LAI, solar zenith angle, leaf
  *   reflectance, transmittance, etc.); extinction coefficients and ambient
  *   flux conversions are pre-computed in the constructor.  Call
  *   `get_light_profile(cumulative_lai)` to evaluate the model at any depth.
  *
- * - `LightProfile` — returned by `get_light_profile`; holds incident PPFD,
+ * - `light_profile` — returned by `get_light_profile`; holds incident PPFD,
  *   incident NIR, absorbed shortwave energy, and leaf-area fraction for each
  *   of the sunlit and shaded leaf classes at a given cumulative LAI depth.
  *
  * **Users of this file:**
- * - `photosynthesis.h` — `CanopyIntegrand` calls `get_light_profile` at each
+ * - `photosynthesis.h` — `canopy_integrand` calls `get_light_profile` at each
  *   quadrature node to supply radiation inputs to the leaf photosynthesis
  *   function.
  * - `multilayer_canopy_properties` — samples `get_light_profile` at `nlayers`
  *   discrete midpoints and writes per-layer values as BioCro module outputs.
  */
-namespace PhotoCore
+namespace core
 {
 
-struct LightProfile {
-    struct LightType {
+struct light_profile {
+    struct light_type {
         double fraction;
         double absorbed_ppfd;
         double absorbed_shortwave;
@@ -43,23 +43,21 @@ struct LightProfile {
         double incident_ppfd;
     };
 
-    double height;     // m
-    LightType shaded;  // micromol / (m^2 leaf) / s
-    LightType sunlit;  // micromol / (m^2 leaf) / s
+    double height;      // m
+    light_type shaded;  // micromol / (m^2 leaf) / s
+    light_type sunlit;  // micromol / (m^2 leaf) / s
 };
 
 double thin_layer_absorption(
     double leaf_reflectance,    // dimensionless
     double leaf_transmittance,  // dimensionless
-    double incident_light       // Light units such as `micromol / m^2 / s` or
-                                //   `J / m^2 / s`
+    double incident_light       // micromol / m^2 / s or J / m^2 / s
 );
 
 double thick_layer_absorption(
     double leaf_reflectance,    // dimensionless
     double leaf_transmittance,  // dimensionless
-    double incident_light       // Light units such as `micromol / m^2 / s` or
-                                //   `J / m^2 / s`
+    double incident_light       // micromol / m^2 / s or J / m^2 / s
 );
 
 double nir_from_ppfd(
@@ -79,29 +77,29 @@ double absorbed_shortwave(
 );
 
 double total_radiation(
-    double Q_o,    // Light units such as `micromol / m^2 / s` or `J / m^2 / s`
+    double Q_o,    // micromol / m^2 / s or J / m^2 / s
     double k,      // dimensionless
     double alpha,  // dimensionless
     double ell     // dimensionless from m^2 leaf / m^2 ground
 );
 
 double downscattered_radiation(
-    double Q_ob,   // Light units such as `micromol / m^2 / s` or `J / m^2 / s`
+    double Q_ob,   // micromol / m^2 / s or J / m^2 / s
     double k,      // dimensionless
     double alpha,  // dimensionless
     double ell     // dimensionless from m^2 leaf / m^2 ground
 );
 
 double shaded_radiation(
-    double Q_ob,       // Light units such as `micromol / m^2 / s` or `J / m^2 / s`
-    double Q_od,       // same units as `Q_ob`
+    double Q_ob,       // micromol / m^2 / s or J / m^2 / s
+    double Q_od,       // same units as Q_ob
     double k_direct,   // dimensionless
     double k_diffuse,  // dimensionless
     double alpha,      // dimensionless
     double ell         // dimensionless from m^2 leaf / m^2 ground
 );
 
-struct CanopyLight {
+struct canopy_light {
     const double ambient_ppfd_beam;       // micromol / (m^2 beam) / s
     const double ambient_ppfd_diffuse;    // micromol / m^2 / s
     const double chil;                    // dimensionless from m^2 / m^2
@@ -116,9 +114,9 @@ struct CanopyLight {
     const double par_energy_content;      // J / micromol
     const double par_energy_fraction;     // dimensionless
 
-    LightProfile get_light_profile(double cumulative_lai) const;
+    light_profile get_light_profile(double cumulative_lai) const;
 
-    CanopyLight(
+    canopy_light(
         double ambient_ppfd_beam,
         double ambient_ppfd_diffuse,
         double chil,                    // dimensionless from m^2 / m^2
@@ -134,7 +132,7 @@ struct CanopyLight {
         double par_energy_fraction      // dimensionless
     );
 
-    static CanopyLight from_solar(
+    static canopy_light from_solar(
         double solarR,
         double direct_fraction,
         double diffuse_fraction,
@@ -158,18 +156,13 @@ struct CanopyLight {
     double k_direct;
     double canopy_direct_transmission_fraction;  // dimensionless
 
-    // Calculate the ambient direct PPFD through a surface parallel to the ground
     double ambient_ppfd_beam_ground;  // micromol / (m^2 ground) / s
-
-    // Calculate the ambient direct PPFD through a unit area of leaf surface
-    double ambient_ppfd_beam_leaf;  // micromol / (m^2 leaf) / s
-
-    // Calculate related NIR energy fluxes
-    double ambient_nir_beam;         // J / (m^2 beam) / s
-    double ambient_nir_beam_ground;  // J / (m^2 ground) / s
-    double ambient_nir_diffuse;      // J / (m^2 ground) / s
-    double ambient_nir_beam_leaf;
+    double ambient_ppfd_beam_leaf;    // micromol / (m^2 leaf) / s
+    double ambient_nir_beam;          // J / (m^2 beam) / s
+    double ambient_nir_beam_ground;   // J / (m^2 ground) / s
+    double ambient_nir_diffuse;       // J / (m^2 ground) / s
+    double ambient_nir_beam_leaf;     // J / (m^2 leaf) / s
 };
 
-}  // namespace PhotoCore
+}  // namespace core
 #endif

--- a/src/module_library/core/photosynthesis.h
+++ b/src/module_library/core/photosynthesis.h
@@ -1,8 +1,8 @@
 #ifndef CANOPY_PHOTO_CORE_H
 #define CANOPY_PHOTO_CORE_H
 #include <cmath>
-#include "canopy_light_distribution.h"    // CanopyLight, LightProfile
-#include "atmosphere_light_scattering.h"  // AtmosphereLightScattering
+#include "canopy_light_distribution.h"    // canopy_light, light_profile
+#include "atmosphere_light_scattering.h"  // atmosphere_light_scattering
 #include "../../framework/constants.h"
 
 /**
@@ -15,34 +15,34 @@
  *
  * **Key types:**
  *
- * - `LeafAssim` — aggregates all per-leaf photosynthesis outputs (net
+ * - `leaf_assim` — aggregates all per-leaf photosynthesis outputs (net
  *   assimilation, stomatal conductance, transpiration, gross assimilation,
  *   leaf respiration, photorespiration).  It satisfies the vector-space
  *   interface required by the `quadrature::` library — `operator+=` and
  *   scalar `operator*` are defined — so a canopy-integrated value is
- *   obtained by passing a `CanopyIntegrand` directly to a quadrature
- *   function with `T = LeafAssim`.
+ *   obtained by passing a `canopy_integrand` directly to a quadrature
+ *   function with `T = leaf_assim`.
  *
- * - `CanopyIntegrand<LeafPhoto>` — a functor templated on a leaf
+ * - `canopy_integrand<leaf_photo>` — a functor templated on a leaf
  *   photosynthesis callable.  Given a cumulative LAI depth it queries a
- *   `CanopyLight` object for the local radiation environment, calls
- *   `LeafPhoto` separately for the sunlit and shaded leaf classes, and
- *   returns their LAI-fraction-weighted sum as a `LeafAssim`.  This is the
+ *   `canopy_light` object for the local radiation environment, calls
+ *   `leaf_photo` separately for the sunlit and shaded leaf classes, and
+ *   returns their LAI-fraction-weighted sum as a `leaf_assim`.  This is the
  *   integrand passed to `quadrature::gauss_legendre<2>`.
  *
  * **Typical call chain** in a canopy photosynthesis function:
- * 1. Construct `PhotoCore::AtmosphereLightScattering` to split total solar
+ * 1. Construct `core::atmosphere_light_scattering` to split total solar
  *    radiation into direct and diffuse components.
- * 2. Construct `PhotoCore::CanopyLight` from those components plus canopy
+ * 2. Construct `core::canopy_light` from those components plus canopy
  *    structural parameters (LAI, leaf angle, optical properties, etc.).
  * 3. Define a `leaf_photo` lambda wrapping a single-leaf photosynthesis
  *    model (e.g. `c3photoC`) with its energy balance convergence loop.
- * 4. Construct `PhotoCore::CanopyIntegrand(leaf_photo, canopy_light, ...)`.
- * 5. Call `quadrature::gauss_legendre<2, LeafAssim>(integrand, 0, LAI, n)`
- *    to obtain the canopy-integrated `LeafAssim`.
+ * 4. Construct `core::canopy_integrand(leaf_photo, canopy_light, ...)`.
+ * 5. Call `quadrature::gauss_legendre<2, leaf_assim>(integrand, 0, LAI, n)`
+ *    to obtain the canopy-integrated `leaf_assim`.
  */
 
-namespace PhotoCore
+namespace core
 {
 
 // forward declarations
@@ -50,10 +50,13 @@ double leaf_nitrogen_profile(double cumulative_lai, double LeafN, double kpLN);
 double wind_speed_profile(double cumulative_lai, double wind_speed);
 
 /**
- * @brief A simple structure for holding the output of leaf photosynthesis
- * calculations; which will be summed into canopy photosynthesis rates. This type must have vector space operations: vector addition and scalar multiplication.
+ * @brief Aggregates per-leaf photosynthesis outputs for canopy integration.
+ *
+ * Satisfies the vector-space interface required by `quadrature::`: defines
+ * `operator+=` and scalar `operator*` so canopy totals are formed by
+ * weighted summation inside the quadrature loop.
  */
-struct LeafAssim {
+struct leaf_assim {
     double assim = 0;                           //!< Net CO2 assimilation rate (micromol / m^2 / s)
     double stomatal_vapor_conductance = 0;      //!< Stomatal conductance to water vapor (mol / m^2 / s)
     double penman = 0;                          //!< P-M transpiration rate (mmol / m^2 / s)
@@ -64,9 +67,9 @@ struct LeafAssim {
     double transpiration = 0;                   //!< Transpiration rate (Mg / ha / hr)
     double whole_plant_growth_respiration = 0;  //!< Whole-plant growth respiration rate (micromol / m^2 / s)
 
-    LeafAssim() = default;
+    leaf_assim() = default;
 
-    LeafAssim& operator+=(const LeafAssim& rhs)
+    leaf_assim& operator+=(const leaf_assim& rhs)
     {
         assim += rhs.assim;
         stomatal_vapor_conductance += rhs.stomatal_vapor_conductance;
@@ -79,7 +82,7 @@ struct LeafAssim {
         return *this;
     }
 
-    LeafAssim& operator*=(double scalar)
+    leaf_assim& operator*=(double scalar)
     {
         assim *= scalar;
         stomatal_vapor_conductance *= scalar;
@@ -93,32 +96,32 @@ struct LeafAssim {
     }
 };
 
-inline LeafAssim operator+(const LeafAssim& lhs, const LeafAssim& rhs)
+inline leaf_assim operator+(const leaf_assim& lhs, const leaf_assim& rhs)
 {
-    LeafAssim out = lhs;
+    leaf_assim out = lhs;
     out += rhs;
     return out;
 }
 
-inline LeafAssim operator*(const LeafAssim& lhs, double scalar)
+inline leaf_assim operator*(const leaf_assim& lhs, double scalar)
 {
-    LeafAssim out = lhs;
+    leaf_assim out = lhs;
     out *= scalar;
     return out;
 }
 
-inline LeafAssim operator*(double scalar, const LeafAssim& rhs)
+inline leaf_assim operator*(double scalar, const leaf_assim& rhs)
 {
-    LeafAssim out = rhs;
+    leaf_assim out = rhs;
     out *= scalar;
     return out;
 }
 
-template <typename LeafPhoto, bool UseAbsorbed = true>
-struct CanopyIntegrand {
-    CanopyIntegrand(
-        LeafPhoto photo_func,
-        CanopyLight light_model,
+template <typename leaf_photo, bool use_absorbed = true>
+struct canopy_integrand {
+    canopy_integrand(
+        leaf_photo photo_func,
+        canopy_light light_model,
         double kpLN,
         double leafN,      // micromol / m^2 / s
         double wind_speed  // m / s
@@ -130,40 +133,38 @@ struct CanopyIntegrand {
     {
     }
 
-    LeafAssim operator()(double cumulative_lai)
+    leaf_assim operator()(double cumulative_lai)
     {
-        // Calculations that are the same for sunlit and shaded leaves
         double layer_leafN = leaf_nitrogen_profile(cumulative_lai, leafN, kpLN);
         double layer_wind_speed = wind_speed_profile(cumulative_lai, wind_speed);
-        LightProfile light_profile = canopy_light_model.get_light_profile(cumulative_lai);
+        light_profile lp = canopy_light_model.get_light_profile(cumulative_lai);
 
-        // currently c4 model uses incident ppfd rather than absorbed ppfd but c3 model uses absorbed
-        auto select_ppfd = [](LightProfile::LightType const& lt) -> double {
-            if constexpr (UseAbsorbed)
+        // c4 model uses incident ppfd; c3 model uses absorbed ppfd
+        auto select_ppfd = [](light_profile::light_type const& lt) -> double {
+            if constexpr (use_absorbed)
                 return lt.absorbed_ppfd;
             else
                 return lt.incident_ppfd;
         };
 
-        // Calculations for sunlit leaves.
-        double i_dir = select_ppfd(light_profile.sunlit);        // micromol / m^2 / s
-        double j_dir = light_profile.sunlit.absorbed_shortwave;  // J / m^2 / s
-        LeafAssim leaf_assim = leaf_photosynthesis(i_dir, j_dir, layer_wind_speed, layer_leafN) * light_profile.sunlit.fraction;
+        // Sunlit leaves
+        double i_dir = select_ppfd(lp.sunlit);       // micromol / m^2 / s
+        double j_dir = lp.sunlit.absorbed_shortwave;  // J / m^2 / s
+        leaf_assim la = leaf_photosynthesis(i_dir, j_dir, layer_wind_speed, layer_leafN) * lp.sunlit.fraction;
 
-        // Calculations for shaded leaves.
-        double i_diff = select_ppfd(light_profile.shaded);
-        double j_diff = light_profile.shaded.absorbed_shortwave;  // J / m^2 / s
-        leaf_assim += leaf_photosynthesis(i_diff, j_diff, layer_wind_speed, layer_leafN) * light_profile.shaded.fraction;
-        return leaf_assim;
+        // Shaded leaves
+        double i_diff = select_ppfd(lp.shaded);
+        double j_diff = lp.shaded.absorbed_shortwave;  // J / m^2 / s
+        la += leaf_photosynthesis(i_diff, j_diff, layer_wind_speed, layer_leafN) * lp.shaded.fraction;
+        return la;
     }
 
    private:
-    LeafPhoto leaf_photosynthesis;
-    CanopyLight canopy_light_model;
+    leaf_photo leaf_photosynthesis;
+    canopy_light canopy_light_model;
     double kpLN;
     double leafN;
     double wind_speed;
-    bool use_absorbed;
 };
 
 inline double leaf_nitrogen_profile(double cumulative_lai, double LeafN, double kpLN)
@@ -177,5 +178,5 @@ inline double wind_speed_profile(double cumulative_lai, double wind_speed)
     return wind_speed * std::exp(-k * cumulative_lai);
 }
 
-}  // namespace PhotoCore
+}  // namespace core
 #endif

--- a/src/module_library/multilayer_canopy_properties.cpp
+++ b/src/module_library/multilayer_canopy_properties.cpp
@@ -106,7 +106,7 @@ void multilayer_canopy_properties::run() const
     // that the `sunML` function expects input expects PPFD values, so we must
     // convert photosynthetically active radiation (PAR) to PPFD using the
     // energy content of light in the PAR band
-    PhotoCore::CanopyLight canopy_light_model(
+    core::canopy_light canopy_light_model(
         par_incident_direct / par_energy_content,   // micromol / (m^2 beam) / s
         par_incident_diffuse / par_energy_content,  // micromol / m^2 / s
         chil,
@@ -128,7 +128,7 @@ void multilayer_canopy_properties::run() const
 
     // Update layer-dependent outputs
     double lai_per_layer = lai / nlayers;
-    PhotoCore::LightProfile light_profile;
+    core::light_profile light_profile;
 
     for (int i = 0; i < nlayers; ++i) {
         double cumulative_lai = (0.5 + i) * lai_per_layer;  // midpoint rule
@@ -150,8 +150,8 @@ void multilayer_canopy_properties::run() const
 
         // windspeed is evaluated at top of layer, not midpoint
         double cumulative_lai_at_top = i * lai_per_layer;
-        update(windspeed_ops[i], PhotoCore::wind_speed_profile(cumulative_lai_at_top, windspeed));
-        update(LeafN_ops[i], PhotoCore::leaf_nitrogen_profile(cumulative_lai_at_top, LeafN, kpLN));
+        update(windspeed_ops[i], core::wind_speed_profile(cumulative_lai_at_top, windspeed));
+        update(LeafN_ops[i], core::leaf_nitrogen_profile(cumulative_lai_at_top, LeafN, kpLN));
     }
 
     // Update other outputs

--- a/src/module_library/shortwave_atmospheric_scattering.h
+++ b/src/module_library/shortwave_atmospheric_scattering.h
@@ -4,7 +4,7 @@
 #include "../framework/module.h"
 #include "../framework/constants.h"
 #include "../framework/state_map.h"
-#include "core/atmosphere_light_scattering.h"  // for PhotoCore::AtmosphereLightScattering
+#include "core/atmosphere_light_scattering.h"  // for core::atmosphere_light_scattering
 
 namespace standardBML
 {
@@ -78,7 +78,7 @@ string_vector shortwave_atmospheric_scattering::get_outputs()
 
 void shortwave_atmospheric_scattering::do_operation() const
 {
-    PhotoCore::AtmosphereLightScattering const scattering(
+    core::atmosphere_light_scattering const scattering(
         cosine_zenith_angle,
         atmospheric_pressure,
         atmospheric_transmittance,


### PR DESCRIPTION
@eloch216  This PR reformats the changes in #305 to the biocro style guide. A good job for claude code.  

While I think it's helpful for code readability when type names are typographically distinct from variable names (and I have written in several programming languages where this style rule is enforced by the compiler so its hard habit to break), I'll leave it you to decide which is better.  