### PR TITLE
More careful canopy assimilation tests

### DIFF
--- a/tests/testthat/test.canopy_modules.R
+++ b/tests/testthat/test.canopy_modules.R
@@ -1,7 +1,11 @@
+# Specify the tolerance to use and the default number of layers
+TOLERANCE      <- 1e-6
+DEFAULT_NLAYER <- 10
+
 # Get the first 100 hours of the 2002 soybean weather data
 WEATHER <- soybean_weather[['2002']][seq_len(100), ]
 
-# Run the soybean model
+# Run the default soybean model
 default_soybean_result <- with(soybean, {run_biocro(
     initial_values,
     parameters,
@@ -14,8 +18,7 @@ default_soybean_result <- with(soybean, {run_biocro(
 # Define an alternate version of the soybean model using the `BioCro:c3_canopy`
 # module
 
-# The BioCro:c3_canopy module replaces the following other modules, provided
-# the number of layers is set to 10
+# The BioCro:c3_canopy module replaces several other modules
 direct_modules_to_remove <- c(
     'BioCro:shortwave_atmospheric_scattering',
     'BioCro:incident_shortwave_from_ground_par',
@@ -27,39 +30,33 @@ direct_modules_to_remove <- c(
 alternate_direct_modules <- soybean$direct_modules[!soybean$direct_modules %in% direct_modules_to_remove]
 alternate_direct_modules <- append(alternate_direct_modules, 'BioCro:c3_canopy')
 
+# The BioCro:c3_canopy module needs several other input parameters
 alternate_soybean <- within(soybean, {
     parameters = within(parameters, {
-        nlayers = 10 # needed for BioCro:c3_canopy
-        lnb0 = 0     # needed for BioCro:c3_canopy
-        lnb1 = 0     # needed for BioCro:c3_canopy
+        nlayers = 0
+        lnb0 = 0
+        lnb1 = 0
     })
 
     direct_modules = alternate_direct_modules
 })
 
-test_that('c3_canopy module produces the same results as the default soybean modules', {
-    # Definition must be valid
-    expect_true(
-        with(alternate_soybean, {validate_dynamical_system_inputs(
-            initial_values,
-            parameters,
-            WEATHER,
-            direct_modules,
-            differential_modules,
-            verbose = FALSE
-        )})
-    )
+# Use partial application to create a function that runs the alternate soybean
+# model with a specified number of layers
+pfunc <- with(alternate_soybean, {partial_run_biocro(
+    initial_values,
+    parameters,
+    WEATHER,
+    direct_modules,
+    differential_modules,
+    ode_solver,
+    arg_name = 'nlayers'
+)})
 
+test_that('c3_canopy module produces the same results as the default soybean modules', {
     # Simulation must run without errors
     alternate_soybean_result <- expect_silent(
-        with(alternate_soybean, {run_biocro(
-            initial_values,
-            parameters,
-            WEATHER,
-            direct_modules,
-            differential_modules,
-            ode_solver
-        )})
+        pfunc(list(nlayers = DEFAULT_NLAYER))
     )
 
     # Some columns should be in the default result but not the alternate result
@@ -89,7 +86,34 @@ test_that('c3_canopy module produces the same results as the default soybean mod
         expect_equal(
             alternate_soybean_result[[cn]],
             default_soybean_result[[cn]],
-            tolerance = 1e-3
+            tolerance = TOLERANCE
         )
     }
+})
+
+test_that('c3_canopy module with fewer layers produces different results', {
+    # Check the canopy assimilation rate when fewer layers are used
+    assim_col <- 'canopy_assimilation_rate'
+
+    alternate_soybean_result_fewer <- pfunc(list(nlayers = DEFAULT_NLAYER - 1))
+
+    expect_false(
+        isTRUE(all.equal(
+            alternate_soybean_result_fewer[[assim_col]],
+            default_soybean_result[[assim_col]],
+            tolerance = TOLERANCE
+        ))
+    )
+
+    # Check the canopy assimilation rate when the minimum number of layers is
+    # used
+    alternate_soybean_result_min <- pfunc(list(nlayers = 1))
+
+    expect_false(
+        isTRUE(all.equal(
+            alternate_soybean_result_min[[assim_col]],
+            default_soybean_result[[assim_col]],
+            tolerance = TOLERANCE
+        ))
+    )
 })

--- a/tests/testthat/test.canopy_modules.R
+++ b/tests/testthat/test.canopy_modules.R
@@ -2,18 +2,27 @@
 TOLERANCE      <- 1e-6
 DEFAULT_NLAYER <- 10
 
-# Get the first 100 hours of the 2002 soybean weather data
-WEATHER <- soybean_weather[['2002']][seq_len(100), ]
+# Helping function that takes a subset of rows from a data frame
+df_subset <- function(x) {
+    row_to_keep <- seq(from = 1, to = nrow(x), by = 23)
+    x[row_to_keep, ]
+}
+
+# Get the first 2000 hours of the 2002 soybean weather data; this should be
+# enough time to reach the peak LAI
+WEATHER <- soybean_weather[['2002']][seq_len(2000), ]
 
 # Run the default soybean model
-default_soybean_result <- with(soybean, {run_biocro(
-    initial_values,
-    parameters,
-    WEATHER,
-    direct_modules,
-    differential_modules,
-    ode_solver
-)})
+default_soybean_result <- df_subset(
+    with(soybean, {run_biocro(
+        initial_values,
+        parameters,
+        WEATHER,
+        direct_modules,
+        differential_modules,
+        ode_solver
+    )})
+)
 
 # Define an alternate version of the soybean model using the `BioCro:c3_canopy`
 # module
@@ -56,7 +65,7 @@ pfunc <- with(alternate_soybean, {partial_run_biocro(
 test_that('c3_canopy module produces the same results as the default soybean modules', {
     # Simulation must run without errors
     alternate_soybean_result <- expect_silent(
-        pfunc(list(nlayers = DEFAULT_NLAYER))
+        df_subset(pfunc(list(nlayers = DEFAULT_NLAYER)))
     )
 
     # Some columns should be in the default result but not the alternate result
@@ -95,7 +104,8 @@ test_that('c3_canopy module with fewer layers produces different results', {
     # Check the canopy assimilation rate when fewer layers are used
     assim_col <- 'canopy_assimilation_rate'
 
-    alternate_soybean_result_fewer <- pfunc(list(nlayers = DEFAULT_NLAYER - 1))
+    alternate_soybean_result_fewer <-
+        df_subset(pfunc(list(nlayers = DEFAULT_NLAYER - 1)))
 
     expect_false(
         isTRUE(all.equal(
@@ -107,7 +117,8 @@ test_that('c3_canopy module with fewer layers produces different results', {
 
     # Check the canopy assimilation rate when the minimum number of layers is
     # used
-    alternate_soybean_result_min <- pfunc(list(nlayers = 1))
+    alternate_soybean_result_min <-
+        df_subset(pfunc(list(nlayers = 1)))
 
     expect_false(
         isTRUE(all.equal(


### PR DESCRIPTION
This PR improves the "C3 canopy module tests."

The purpose of these tests is to confirm that the `BioCro:c3_canopy` module produces the same results as the `BioCro:ten_layer_c3_canopy` module when `nlayers` is set to 10.

Here, I have tightened the tolerances. I have also added an additional test that checks whether the `BioCro:c3_canopy` module produces different results for fewer numbers of layers (9 and 1).

I think these more stringent tests will be helpful for PR #305 