### PR TITLE
Update actions to newer versions

### DIFF
--- a/.github/workflows/R-CMD-check-backend.yaml
+++ b/.github/workflows/R-CMD-check-backend.yaml
@@ -176,7 +176,7 @@ jobs:
 
       - name: Check out repository
         if: ${{ !inputs.dry-run }}
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           submodules: true
 

--- a/.github/workflows/R-CMD-check-changes-meaning.yaml
+++ b/.github/workflows/R-CMD-check-changes-meaning.yaml
@@ -31,7 +31,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           submodules: true
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -75,7 +75,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           submodules: true
 

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -65,7 +65,7 @@ jobs:
         echo "VERSION=${GITHUB_REF_NAME////_}" >> $GITHUB_ENV
 
     - name: 1. Check out repository
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v6.0.2
       with:
         submodules: true
 
@@ -114,7 +114,7 @@ jobs:
 
     - name: 7a. Check out the target "PUBLISH_TO" repository
       if: inputs.publish
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v6.0.2
       with:
         repository: ${{ env.PUBLISH_TO }}
         path: ${{ env.BIOCRO_DOCUMENTATION_ROOT }}
@@ -201,7 +201,7 @@ jobs:
 
     - name: 11. Upload artifact containing documentation
       if: always() # Even if some steps fail, at least try to make a documentation artifact.
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v7.0.1
       with:
         name: biocro-documentation-${{ env.VERSION }}
         path: biocro-docs-from-${{ env.VERSION }}.tgz

--- a/.github/workflows/document_quantities.yml
+++ b/.github/workflows/document_quantities.yml
@@ -20,7 +20,7 @@ jobs:
     # Checks out this repository under $GITHUB_WORKSPACE/source:
 
     - name: 1. Check out master
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v6.0.2
       with:
         submodules: true
         path: source
@@ -87,7 +87,7 @@ jobs:
     # check in our changes later, in the Push step:
 
     - name: 10. Check out master of the "publish-to" repository
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v6.0.2
       with:
         repository: ${{ env.publish-to }}
         path: target


### PR DESCRIPTION
I noticed a warning message on some of our GitHub actions:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4.1.1, actions/upload-artifact@v4.4.3. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

It turns out there are much newer versions of the `checkout` and `upload-artifact` actions, so here I am updating them. No idea if this is related to the documentation workflow errors.