### PR TITLE
Small changes

### DIFF
--- a/data/willow.R
+++ b/data/willow.R
@@ -132,7 +132,7 @@ willow <- list(
         lnfun                        = 0,
         longitude                    = -88,
         min_gbw_canopy               = 0.005,
-        nlayers                      = 10,
+        nlayers                      = 2,
         O2                           = 210,
         par_energy_content           = 0.219,
         par_energy_fraction          = 0.5,

--- a/src/module_library/BioCro.h
+++ b/src/module_library/BioCro.h
@@ -4,12 +4,69 @@
 #include <vector>
 #include "AuxBioCro.h"
 
-ws_str watstr(double precipit, double evapo, double cws, double soildepth, double fieldc, double wiltp, double soil_saturation_capacity, double soil_sand_content, double Ks, double air_entry, double b);
+ws_str watstr(
+    double precipit,
+    double evapo,
+    double cws,
+    double soildepth,
+    double fieldc,
+    double wiltp,
+    double soil_saturation_capacity,
+    double sand,
+    double Ks,
+    double air_entry,
+    double b);
 
 double SoilEvapo(
-    double LAI, double k, double air_temperature, double ppfd, double soil_water_content, double fieldc, double wiltp, double winds, double RelH, double rsec, double soil_clod_size, double soil_reflectance, double soil_transmission, double specific_heat_of_air, double par_energy_content);
+    double LAI,
+    double k,
+    double air_temperature,
+    double ppfd,
+    double soil_water_content,
+    double fieldc,
+    double wiltp,
+    double winds,
+    double RelH,
+    double rsec,
+    double soil_clod_size,
+    double soil_reflectance,
+    double soil_transmission,
+    double specific_heat_of_air,
+    double par_energy_content);
 
-soilML_str soilML(double precipit, double transp, double* cws, double soildepth, double* depths, double soil_field_capacity, double soil_wilting_point, double soil_saturation_capacity, double soil_air_entry, double soil_saturated_conductivity, double soil_b_coefficient, double soil_sand_content, double phi1, double phi2, int wsFun, int layers, double rootDB, double LAI, double k, double AirTemp, double IRad, double winds, double RelH, int hydrDist, double rfl, double rsec, double rsdf, double soil_clod_size, double soil_reflectance, double soil_transmission, double specific_heat_of_air, double par_energy_content);
+soilML_str soilML(
+    double precipit,
+    double transp,
+    double* cws,
+    double soildepth,
+    double* depths,
+    double soil_field_capacity,
+    double soil_wilting_point,
+    double soil_saturation_capacity,
+    double soil_air_entry,
+    double soil_saturated_conductivity,
+    double soil_b_coefficient,
+    double soil_sand_content,
+    double phi1,
+    double phi2,
+    int wsFun,
+    int layers,
+    double rootDB,
+    double LAI,
+    double k,
+    double AirTemp,
+    double IRad,
+    double winds,
+    double RelH,
+    int hydrDist,
+    double rfl,
+    double rsec,
+    double rsdf,
+    double soil_clod_size,
+    double soil_reflectance,
+    double soil_transmission,
+    double specific_heat_of_air,
+    double par_energy_content);
 
 double AbiotEff(double smoist, double stemp);
 

--- a/src/module_library/BioCro.h
+++ b/src/module_library/BioCro.h
@@ -68,6 +68,4 @@ soilML_str soilML(
     double specific_heat_of_air,
     double par_energy_content);
 
-double AbiotEff(double smoist, double stemp);
-
 #endif

--- a/src/module_library/core/photosynthesis.h
+++ b/src/module_library/core/photosynthesis.h
@@ -44,7 +44,6 @@
 
 namespace core
 {
-
 // forward declarations
 double leaf_nitrogen_profile(double cumulative_lai, double LeafN, double kpLN);
 double wind_speed_profile(double cumulative_lai, double wind_speed);
@@ -57,15 +56,14 @@ double wind_speed_profile(double cumulative_lai, double wind_speed);
  * weighted summation inside the quadrature loop.
  */
 struct leaf_assim {
-    double assim = 0;                           //!< Net CO2 assimilation rate (micromol / m^2 / s)
-    double stomatal_vapor_conductance = 0;      //!< Stomatal conductance to water vapor (mol / m^2 / s)
-    double penman = 0;                          //!< P-M transpiration rate (mmol / m^2 / s)
-    double priestly = 0;                        //!< Priestly transpiration rate (mmol / m^2 / s)
-    double carboxylation = 0;                   //!< Gross CO2 assimilation rate (micromol / m^2 / s)
-    double leaf_respiration = 0;                //!< Rate of non-photorespiratory CO2 release in the light (micromol / m^2 / s)
-    double photorespiration = 0;                //!< Rate of photorespiration (micromol / m^2 / s)
-    double transpiration = 0;                   //!< Transpiration rate (Mg / ha / hr)
-    double whole_plant_growth_respiration = 0;  //!< Whole-plant growth respiration rate (micromol / m^2 / s)
+    double assim = 0;                       //!< Net CO2 assimilation rate (micromol / m^2 / s)
+    double stomatal_vapor_conductance = 0;  //!< Stomatal conductance to water vapor (mol / m^2 / s)
+    double penman = 0;                      //!< P-M transpiration rate (mmol / m^2 / s)
+    double priestly = 0;                    //!< Priestly transpiration rate (mmol / m^2 / s)
+    double carboxylation = 0;               //!< Gross CO2 assimilation rate (micromol / m^2 / s)
+    double leaf_respiration = 0;            //!< Rate of non-photorespiratory CO2 release in the light (micromol / m^2 / s)
+    double photorespiration = 0;            //!< Rate of photorespiration (micromol / m^2 / s)
+    double transpiration = 0;               //!< Transpiration rate (Mg / ha / hr)
 
     leaf_assim() = default;
 
@@ -148,7 +146,7 @@ struct canopy_integrand {
         };
 
         // Sunlit leaves
-        double i_dir = select_ppfd(lp.sunlit);       // micromol / m^2 / s
+        double i_dir = select_ppfd(lp.sunlit);        // micromol / m^2 / s
         double j_dir = lp.sunlit.absorbed_shortwave;  // J / m^2 / s
         leaf_assim la = leaf_photosynthesis(i_dir, j_dir, layer_wind_speed, layer_leafN) * lp.sunlit.fraction;
 


### PR DESCRIPTION
I noticed that the `leaf_assim` `struct` had a member called `whole_plant_growth_respiration` that was not used. Conceptually, this should not be in a leaf-level representation of assimilation, since it applies at the canopy (or whole-plant) level. So, I removed it.

I also reformatted some extremely long lines that had appeared due to `clang-format`.

While doing that, I noticed a function that was defined but never implemented anywhere (`AbiotEff`). This has nothing to do with the canopy integrals, but we might as well remove it here while we are altering `BioCro.h`.