### PR TITLE
Update from dev

### DIFF
--- a/.github/actions/build_pkgdown_site/action.yml
+++ b/.github/actions/build_pkgdown_site/action.yml
@@ -21,16 +21,12 @@ runs:
         use-public-rspm: true
 
     - name: Install TinyTex
+      uses: r-lib/actions/setup-tinytex@v2
+
+    - name: Update TeX Live
       run: |
-        install.packages('tinytex')
-        tinytex::install_tinytex()
-
-        # (tinytex::pdflatex, which is called by the
-        # pdf_vignette_index.Rmd vignette, will automatically install
-        # any additional needed LaTeX packages needed by the Rnw
-        # vignettes.)
-
-      shell: Rscript {0}
+        tlmgr update --self
+        tlmgr update --all
 
     - name: Add the appropriate URL setting to the configuration file
       working-directory: ${{ inputs.package_root }}/pkgdown

--- a/.github/actions/build_pkgdown_site/action.yml
+++ b/.github/actions/build_pkgdown_site/action.yml
@@ -32,7 +32,6 @@ runs:
     - name: Install TinyTex
       run: |
         install.packages('tinytex')
-        tinytex::install_tinytex()
 
         # (tinytex::pdflatex, which is called by the
         # pdf_vignette_index.Rmd vignette, will automatically install

--- a/.github/actions/build_pkgdown_site/action.yml
+++ b/.github/actions/build_pkgdown_site/action.yml
@@ -20,13 +20,25 @@ runs:
         r-version: "release"
         use-public-rspm: true
 
-    - name: Install TinyTex
+    - name: Set up TinyTex
       uses: r-lib/actions/setup-tinytex@v2
 
     - name: Update TeX Live
       run: |
         tlmgr update --self
         tlmgr update --all
+      shell: bash
+
+    - name: Install TinyTex
+      run: |
+        install.packages('tinytex')
+        tinytex::install_tinytex()
+
+        # (tinytex::pdflatex, which is called by the
+        # pdf_vignette_index.Rmd vignette, will automatically install
+        # any additional needed LaTeX packages needed by the Rnw
+        # vignettes.)
+      shell: Rscript {0}
 
     - name: Add the appropriate URL setting to the configuration file
       working-directory: ${{ inputs.package_root }}/pkgdown

--- a/.github/workflows/R-CMD-check-backend.yaml
+++ b/.github/workflows/R-CMD-check-backend.yaml
@@ -176,7 +176,7 @@ jobs:
 
       - name: Check out repository
         if: ${{ !inputs.dry-run }}
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           submodules: true
 

--- a/.github/workflows/R-CMD-check-changes-meaning.yaml
+++ b/.github/workflows/R-CMD-check-changes-meaning.yaml
@@ -31,7 +31,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           submodules: true
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -75,7 +75,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           submodules: true
 

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -65,7 +65,7 @@ jobs:
         echo "VERSION=${GITHUB_REF_NAME////_}" >> $GITHUB_ENV
 
     - name: 1. Check out repository
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v6.0.2
       with:
         submodules: true
 
@@ -114,7 +114,7 @@ jobs:
 
     - name: 7a. Check out the target "PUBLISH_TO" repository
       if: inputs.publish
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v6.0.2
       with:
         repository: ${{ env.PUBLISH_TO }}
         path: ${{ env.BIOCRO_DOCUMENTATION_ROOT }}
@@ -201,7 +201,7 @@ jobs:
 
     - name: 11. Upload artifact containing documentation
       if: always() # Even if some steps fail, at least try to make a documentation artifact.
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v7.0.1
       with:
         name: biocro-documentation-${{ env.VERSION }}
         path: biocro-docs-from-${{ env.VERSION }}.tgz

--- a/.github/workflows/document_quantities.yml
+++ b/.github/workflows/document_quantities.yml
@@ -20,7 +20,7 @@ jobs:
     # Checks out this repository under $GITHUB_WORKSPACE/source:
 
     - name: 1. Check out master
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v6.0.2
       with:
         submodules: true
         path: source
@@ -87,7 +87,7 @@ jobs:
     # check in our changes later, in the Push step:
 
     - name: 10. Check out master of the "publish-to" repository
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v6.0.2
       with:
         repository: ${{ env.publish-to }}
         path: target

--- a/tests/testthat/test.canopy_modules.R
+++ b/tests/testthat/test.canopy_modules.R
@@ -90,6 +90,9 @@ test_that('c3_canopy module produces the same results as the default soybean mod
         all(col_to_check %in% colnames(alternate_soybean_result))
     )
 
+    # Skip remaining tests in this chunk
+    skip('c3_canopy now uses quadrature and hence does not agree with ten_layer_c3_canopy')
+
     # Key columns must have the same values in both results
     for (cn in col_to_check) {
         expect_equal(

--- a/tests/testthat/test.canopy_modules.R
+++ b/tests/testthat/test.canopy_modules.R
@@ -1,7 +1,11 @@
+# Specify the tolerance to use and the default number of layers
+TOLERANCE      <- 1e-6
+DEFAULT_NLAYER <- 10
+
 # Get the first 100 hours of the 2002 soybean weather data
 WEATHER <- soybean_weather[['2002']][seq_len(100), ]
 
-# Run the soybean model
+# Run the default soybean model
 default_soybean_result <- with(soybean, {run_biocro(
     initial_values,
     parameters,
@@ -14,8 +18,7 @@ default_soybean_result <- with(soybean, {run_biocro(
 # Define an alternate version of the soybean model using the `BioCro:c3_canopy`
 # module
 
-# The BioCro:c3_canopy module replaces the following other modules, provided
-# the number of layers is set to 10
+# The BioCro:c3_canopy module replaces several other modules
 direct_modules_to_remove <- c(
     'BioCro:shortwave_atmospheric_scattering',
     'BioCro:incident_shortwave_from_ground_par',
@@ -27,39 +30,33 @@ direct_modules_to_remove <- c(
 alternate_direct_modules <- soybean$direct_modules[!soybean$direct_modules %in% direct_modules_to_remove]
 alternate_direct_modules <- append(alternate_direct_modules, 'BioCro:c3_canopy')
 
+# The BioCro:c3_canopy module needs several other input parameters
 alternate_soybean <- within(soybean, {
     parameters = within(parameters, {
-        nlayers = 10 # needed for BioCro:c3_canopy
-        lnb0 = 0     # needed for BioCro:c3_canopy
-        lnb1 = 0     # needed for BioCro:c3_canopy
+        nlayers = 0
+        lnb0 = 0
+        lnb1 = 0
     })
 
     direct_modules = alternate_direct_modules
 })
 
-test_that('c3_canopy module produces the same results as the default soybean modules', {
-    # Definition must be valid
-    expect_true(
-        with(alternate_soybean, {validate_dynamical_system_inputs(
-            initial_values,
-            parameters,
-            WEATHER,
-            direct_modules,
-            differential_modules,
-            verbose = FALSE
-        )})
-    )
+# Use partial application to create a function that runs the alternate soybean
+# model with a specified number of layers
+pfunc <- with(alternate_soybean, {partial_run_biocro(
+    initial_values,
+    parameters,
+    WEATHER,
+    direct_modules,
+    differential_modules,
+    ode_solver,
+    arg_name = 'nlayers'
+)})
 
+test_that('c3_canopy module produces the same results as the default soybean modules', {
     # Simulation must run without errors
     alternate_soybean_result <- expect_silent(
-        with(alternate_soybean, {run_biocro(
-            initial_values,
-            parameters,
-            WEATHER,
-            direct_modules,
-            differential_modules,
-            ode_solver
-        )})
+        pfunc(list(nlayers = DEFAULT_NLAYER))
     )
 
     # Some columns should be in the default result but not the alternate result
@@ -89,7 +86,34 @@ test_that('c3_canopy module produces the same results as the default soybean mod
         expect_equal(
             alternate_soybean_result[[cn]],
             default_soybean_result[[cn]],
-            tolerance = 1e-3
+            tolerance = TOLERANCE
         )
     }
+})
+
+test_that('c3_canopy module with fewer layers produces different results', {
+    # Check the canopy assimilation rate when fewer layers are used
+    assim_col <- 'canopy_assimilation_rate'
+
+    alternate_soybean_result_fewer <- pfunc(list(nlayers = DEFAULT_NLAYER - 1))
+
+    expect_false(
+        isTRUE(all.equal(
+            alternate_soybean_result_fewer[[assim_col]],
+            default_soybean_result[[assim_col]],
+            tolerance = TOLERANCE
+        ))
+    )
+
+    # Check the canopy assimilation rate when the minimum number of layers is
+    # used
+    alternate_soybean_result_min <- pfunc(list(nlayers = 1))
+
+    expect_false(
+        isTRUE(all.equal(
+            alternate_soybean_result_min[[assim_col]],
+            default_soybean_result[[assim_col]],
+            tolerance = TOLERANCE
+        ))
+    )
 })

--- a/tests/testthat/test.canopy_modules.R
+++ b/tests/testthat/test.canopy_modules.R
@@ -2,18 +2,27 @@
 TOLERANCE      <- 1e-6
 DEFAULT_NLAYER <- 10
 
-# Get the first 100 hours of the 2002 soybean weather data
-WEATHER <- soybean_weather[['2002']][seq_len(100), ]
+# Helping function that takes a subset of rows from a data frame
+df_subset <- function(x) {
+    row_to_keep <- seq(from = 1, to = nrow(x), by = 23)
+    x[row_to_keep, ]
+}
+
+# Get the first 2000 hours of the 2002 soybean weather data; this should be
+# enough time to reach the peak LAI
+WEATHER <- soybean_weather[['2002']][seq_len(2000), ]
 
 # Run the default soybean model
-default_soybean_result <- with(soybean, {run_biocro(
-    initial_values,
-    parameters,
-    WEATHER,
-    direct_modules,
-    differential_modules,
-    ode_solver
-)})
+default_soybean_result <- df_subset(
+    with(soybean, {run_biocro(
+        initial_values,
+        parameters,
+        WEATHER,
+        direct_modules,
+        differential_modules,
+        ode_solver
+    )})
+)
 
 # Define an alternate version of the soybean model using the `BioCro:c3_canopy`
 # module
@@ -56,7 +65,7 @@ pfunc <- with(alternate_soybean, {partial_run_biocro(
 test_that('c3_canopy module produces the same results as the default soybean modules', {
     # Simulation must run without errors
     alternate_soybean_result <- expect_silent(
-        pfunc(list(nlayers = DEFAULT_NLAYER))
+        df_subset(pfunc(list(nlayers = DEFAULT_NLAYER)))
     )
 
     # Some columns should be in the default result but not the alternate result
@@ -95,7 +104,8 @@ test_that('c3_canopy module with fewer layers produces different results', {
     # Check the canopy assimilation rate when fewer layers are used
     assim_col <- 'canopy_assimilation_rate'
 
-    alternate_soybean_result_fewer <- pfunc(list(nlayers = DEFAULT_NLAYER - 1))
+    alternate_soybean_result_fewer <-
+        df_subset(pfunc(list(nlayers = DEFAULT_NLAYER - 1)))
 
     expect_false(
         isTRUE(all.equal(
@@ -107,7 +117,8 @@ test_that('c3_canopy module with fewer layers produces different results', {
 
     # Check the canopy assimilation rate when the minimum number of layers is
     # used
-    alternate_soybean_result_min <- pfunc(list(nlayers = 1))
+    alternate_soybean_result_min <-
+        df_subset(pfunc(list(nlayers = 1)))
 
     expect_false(
         isTRUE(all.equal(


### PR DESCRIPTION
This PR updates from `develop` to take advantage of more thorough tests in `test.canopy_modules.R`, and to fix some spurious check failures due to an issue with the testing workflow.

The new canopy test confirms that `c3_canopy` and `ten_layer_c3_canopy` no longer agree with each other. I had suspected this, but the test helped to confirm.

I tried testing out different values of `nlayers` for `c3_canopy`, but the first part of the test ("c3_canopy module produces the same results as the default soybean modules") always failed.

I could get the first part of the test to pass by using a very high tolerance (`1e-2`). But then in that case, the second part of the test ("c3_canopy module with fewer layers produces different results") failed. In other words, that tolerance is so loose that we cannot detect the difference between N and N-1 layers.

So, for now, part of the test must be disabled.