### PR TITLE
fix some compile issues on Mac

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,4 @@
-PKG_CPPFLAGS+=-I../src/inc -DR_NO_REMAP
+PKG_CPPFLAGS += -isystem ../src/inc -DR_NO_REMAP
 
 SOURCES = $(wildcard *.cpp module_library/*.cpp  module_library/core/*.cpp framework/*.cpp framework/ode_solver_library/*.cpp framework/utils/*.cpp math/roots/onedim/*.cpp)
 OBJECTS = $(SOURCES:.cpp=.o)

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,4 @@
-PKG_CPPFLAGS += -isystem ../src/inc -DR_NO_REMAP
+PKG_CPPFLAGS+=-I../src/inc -DR_NO_REMAP
 
 SOURCES = $(wildcard *.cpp module_library/*.cpp  module_library/core/*.cpp framework/*.cpp framework/ode_solver_library/*.cpp framework/utils/*.cpp math/roots/onedim/*.cpp)
 OBJECTS = $(SOURCES:.cpp=.o)

--- a/src/math/roots/multidim/broyden.h
+++ b/src/math/roots/multidim/broyden.h
@@ -40,7 +40,7 @@ namespace root_multidim
 template <size_t Dim>
 struct broyden : public zero_finding_method<Dim, broyden<Dim>> {
     // zero_finding_method methods can call private methods defined here
-    friend class zero_finding_method<Dim, broyden<Dim>>::zero_finding_method;
+    friend struct zero_finding_method<Dim, broyden<Dim>>;
 
     // "import" parent class methods
     using zero_finding_method<Dim, broyden<Dim>>::zero_finding_method;

--- a/src/math/roots/multidim/newton.h
+++ b/src/math/roots/multidim/newton.h
@@ -44,7 +44,7 @@ template <size_t Dim>
 struct newton : public zero_finding_method<Dim, newton<Dim>> {
     using zero_finding_method<Dim, newton<Dim>>::zero_finding_method;
 
-    friend class zero_finding_method<Dim, newton<Dim>>::zero_finding_method;
+    friend struct zero_finding_method<Dim, newton<Dim>>;
 
    private:
     using vec_t = typename linalg::vector<double, Dim>;

--- a/src/module_library/multi_layer_soil_profile.h
+++ b/src/module_library/multi_layer_soil_profile.h
@@ -215,7 +215,7 @@ string_vector multi_layer_soil_profile::get_outputs()
 
 void multi_layer_soil_profile::do_operation() const
 {
-    int nlayers = 6;
+    int constexpr nlayers = 6;
 
     double soil_depth[] = {
         soil_depth_1,  // cm

--- a/src/module_library/soil_water_flow_functions.cpp
+++ b/src/module_library/soil_water_flow_functions.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>  // for std::min, std::max
 #include <cmath>      // for exp, fabs
+#include <vector>
 #include "soil_water_flow_functions.h"
 
 /**
@@ -86,8 +87,8 @@ infilWater_str infil(
     double constexpr swconrf = 0.9;     // dimensionless - swcon reduction factor
 
     // Initialize layer-dependent variables
-    double downward_flux[nlayers];  // cm / hr   - Total downward water flux (drainage and infiltration)
-    double swtemp[nlayers];         // m^3 / m^3 - Soil water content
+    std::vector<double> downward_flux(nlayers);  // cm / hr   - Total downward water flux (drainage and infiltration)
+    std::vector<double> swtemp(nlayers);         // m^3 / m^3 - Soil water content
 
     for (int l = 0; l < nlayers; l++) {
         downward_flux[l] = 0.0;             // cm / hr
@@ -318,8 +319,8 @@ infilWater_str satflo(
     double constexpr mm_per_cm = 10.0;  // mm / cm
 
     // Initialize layer-dependent variables
-    double downward_flux[nlayers]{0.0};  // cm / hr   - Total downward water flux (drainage and infiltration)
-    double swtemp[nlayers];              // m^3 / m^3 - Soil water content
+    std::vector<double> downward_flux(nlayers, 0.0);  // cm / hr   - Total downward water flux (drainage and infiltration)
+    std::vector<double> swtemp(nlayers);               // m^3 / m^3 - Soil water content
 
     for (int l = 0; l < nlayers; l++) {
         swtemp[l] = soil_water_content[l];  // m^3 / m^3
@@ -486,11 +487,11 @@ upwardFlo_str up_flow(
     double const soil_diffusivity_hr = soil_diffusivity / hours_per_day;  // cm / hr
 
     // Initialize layer-dependent values
-    double upward_flux[nlayers];  // cm / hr
-    double swtemp[nlayers];       // m^3 / m^3 - soil water content (temporary value)
-    double sw_inf[nlayers];       // m^3 / m^3 - soil water content including computed upward flow
-    double sw_avail[nlayers];     // m^3 / m^3 - soil water content available for evaporation, plant extraction, or movement through soil
-    double esw[nlayers];          // m^3 / m^3 - plant extractable soil water
+    std::vector<double> upward_flux(nlayers);  // cm / hr
+    std::vector<double> swtemp(nlayers);       // m^3 / m^3 - soil water content (temporary value)
+    std::vector<double> sw_inf(nlayers);       // m^3 / m^3 - soil water content including computed upward flow
+    std::vector<double> sw_avail(nlayers);     // m^3 / m^3 - soil water content available for evaporation, plant extraction, or movement through soil
+    std::vector<double> esw(nlayers);          // m^3 / m^3 - plant extractable soil water
 
     // Calculated flow will be limited by SW_INF and SW_AVAIL
 
@@ -633,8 +634,8 @@ tileDrain_str tile_flow(
     double constexpr sat_thresh = 0.98;  // dimensionless
 
     // Initialize layer-dependent values
-    double drn[nlayers];      // cm
-    double swdeltT[nlayers];  // m^3 / m^3
+    std::vector<double> drn(nlayers);      // cm
+    std::vector<double> swdeltT(nlayers);  // m^3 / m^3
 
     for (int l = 0; l < nlayers; l++) {
         drn[l] = 0.0;      // cm


### PR DESCRIPTION
This PR fixes the macOS compilation error and related warnings reported in PR #335.
## Changes

- Replace variable-length arrays in `soil_water_flow_functions.cpp` with
  `std::vector`.
- Make the fixed six-layer count in `multi_layer_soil_profile` a `constexpr`
  constant.
- Make the `zero_finding_method` friend declarations consistently use `struct`.
- Treat the BioCro's copy of the Boost directory as a system include directory, suppressing
  clang's warnings originating from third-party Boost headers.

The change from `-I` to `-isystem` only affects compiler diagnostics and header
dependency tracking; Boost remains available from the same directory.

## Update
Looks like `-isystem` is not allowed here. So I just changed back to `-I`.