### PR TITLE
Add checks to make sure RH is not a percentage

### DIFF
--- a/src/module_library/ball_berry_gs.cpp
+++ b/src/module_library/ball_berry_gs.cpp
@@ -106,6 +106,11 @@ stomata_outputs ball_berry_gs(
     double ambient_air_temperature  // degrees C
 )
 {
+    // Check for error conditions (ambient_rh not in [0,1])
+    if (ambient_rh < -eps_zero || ambient_rh > 1.0 + eps_zero) {
+        throw std::range_error("Thrown in ball_berry_gs: ambient_rh does not lie in the interval [0, 1].");
+    }
+
     // If An < 0, set b1 = 0 to ensure that gsw = b0 in Equation (1) as defined
     // above
     if (assimilation < 0) {

--- a/src/module_library/leaf_energy_balance.cpp
+++ b/src/module_library/leaf_energy_balance.cpp
@@ -7,6 +7,8 @@
 #include "water_and_air_properties.h"     // for TempToCp, dry_air_density, etc
 #include "leaf_energy_balance.h"
 
+using calculation_constants::eps_zero;
+
 /**
  *  @brief Calculates the total energy available to the leaf for transpiration
  *  and sensible heat loss, often denoted as \f$ \Phi_N \f$.
@@ -156,6 +158,11 @@ energy_balance_outputs leaf_energy_balance(
     double wind_speed                  // m / s
 )
 {
+    // Check for error conditions (relative_humidity not in [0,1])
+    if (relative_humidity < -eps_zero || relative_humidity > 1.0 + eps_zero) {
+        throw std::range_error("Thrown in leaf_energy_balance: relative_humidity does not lie in the interval [0, 1].");
+    }
+
     // Set some constants
     double constexpr epsilon_s = 1.0;  // dimensionless
 

--- a/src/module_library/leaf_gbw_nikolov.h
+++ b/src/module_library/leaf_gbw_nikolov.h
@@ -3,6 +3,7 @@
 
 #include "../framework/module.h"
 #include "../framework/state_map.h"
+#include "../framework/constants.h"      // for eps_zero
 #include "conductance_helpers.h"         // for g_to_mass
 #include "water_and_air_properties.h"    // for saturation_vapor_pressure, molar_volume
 #include "boundary_layer_conductance.h"  // for leaf_boundary_layer_conductance_nikolov
@@ -79,6 +80,13 @@ string_vector leaf_gbw_nikolov::get_outputs()
 
 void leaf_gbw_nikolov::do_operation() const
 {
+    using calculation_constants::eps_zero;
+
+    // Check for error conditions (rh not in [0,1])
+    if (rh < -eps_zero || rh > 1.0 + eps_zero) {
+        throw std::range_error("Thrown in leaf_gbw_nikolov: rh does not lie in the interval [0, 1].");
+    }
+
     // Determine the partial pressure of water vapor from the air temperature
     // and relative humidity
     const double SWVP = saturation_vapor_pressure(air_temperature);  // Pa

--- a/src/module_library/rh_to_mole_fraction.h
+++ b/src/module_library/rh_to_mole_fraction.h
@@ -90,11 +90,13 @@ string_vector rh_to_mole_fraction::get_outputs()
 
 void rh_to_mole_fraction::do_operation() const
 {
+    using calculation_constants::eps_zero;
+
     // Check for possible error conditions:
     // atmospheric_pressure == 0 causes a division by zero
     std::map<std::string, bool> errors_to_check = {
-        {"atmospheric_pressure cannot be zero",
-         std::abs(atmospheric_pressure) < calculation_constants::eps_zero}};
+        {"atmospheric_pressure cannot be zero", std::abs(atmospheric_pressure) < eps_zero},
+        {"rh must lie in the interval [0, 1]", rh < -eps_zero || rh > 1.0 + eps_zero}};
 
     check_error_conditions(errors_to_check, get_name());
 

--- a/src/module_library/soil_evaporation.h
+++ b/src/module_library/soil_evaporation.h
@@ -3,7 +3,8 @@
 
 #include "../framework/module.h"
 #include "../framework/state_map.h"
-#include "BioCro.h"  // For SoilEvapo
+#include "../framework/constants.h"  // for eps_zero
+#include "BioCro.h"                  // For SoilEvapo
 
 namespace standardBML
 {
@@ -92,7 +93,13 @@ string_vector soil_evaporation::get_outputs()
 
 void soil_evaporation::do_operation() const
 {
-    // Collect inputs and make calculations
+    using calculation_constants::eps_zero;
+
+    // Check for error conditions (rh not in [0,1])
+    if (rh < -eps_zero || rh > 1.0 + eps_zero) {
+        throw std::range_error("Thrown in soil_evaporation: rh does not lie in the interval [0, 1].");
+    }
+
     // SoilEvapo(...) is located in AuxBioCro.cpp
     double soilEvap = SoilEvapo(
         lai, 0.68, temp, solar, soil_water_content, soil_field_capacity,

--- a/src/module_library/soil_evaporation_ritchie.h
+++ b/src/module_library/soil_evaporation_ritchie.h
@@ -356,6 +356,11 @@ void soil_evaporation_ritchie::do_operation() const
     using std::max;
     using std::min;
 
+    // Check for error conditions (rh not in [0,1])
+    if (rh < -eps_zero || rh > 1.0 + eps_zero) {
+        throw std::range_error("Thrown in soil_evaporation_ritchie: rh does not lie in the interval [0, 1].");
+    }
+
     // Define conversion constants to avoid magic numbers
     double constexpr cm_to_mm = 10.0;       // mm / cm
     double constexpr hours_per_day = 24.0;  // hr / day

--- a/src/module_library/two_layer_soil_profile.h
+++ b/src/module_library/two_layer_soil_profile.h
@@ -3,8 +3,9 @@
 
 #include "../framework/module.h"
 #include "../framework/state_map.h"
-#include "AuxBioCro.h"  // For soilML_str
-#include "BioCro.h"     // For soilML
+#include "../framework/constants.h"  // for eps_zero
+#include "AuxBioCro.h"               // For soilML_str
+#include "BioCro.h"                  // For soilML
 
 namespace standardBML
 {
@@ -156,6 +157,13 @@ string_vector two_layer_soil_profile::get_outputs()
 
 void two_layer_soil_profile::do_operation() const
 {
+    using calculation_constants::eps_zero;
+
+    // Check for error conditions (rh not in [0,1])
+    if (rh < -eps_zero || rh > 1.0 + eps_zero) {
+        throw std::range_error("Thrown in two_layer_soil_profile: rh does not lie in the interval [0, 1].");
+    }
+
     // Collect inputs and make calculations
     double cws[] = {cws1, cws2};
     double soil_depths[] = {soil_depth1, soil_depth2, soil_depth3};

--- a/src/module_library/water_vapor_properties_from_air_temperature.h
+++ b/src/module_library/water_vapor_properties_from_air_temperature.h
@@ -5,7 +5,7 @@
 #include "../framework/state_map.h"
 #include "water_and_air_properties.h"  // for saturation_vapor_pressure,
                                        // TempToSFS, TempToLHV, TempToDdryA
-#include "../framework/constants.h"    // for ideal_gas_constant,
+#include "../framework/constants.h"    // for ideal_gas_constant, eps_zero,
                                        // molar_mass_of_water, celsius_to_kelvin
 
 namespace standardBML
@@ -77,8 +77,14 @@ string_vector water_vapor_properties_from_air_temperature::get_outputs()
 
 void water_vapor_properties_from_air_temperature::do_operation() const
 {
-    // Collect input quantities and make calculations
+    using calculation_constants::eps_zero;
 
+    // Check for error conditions (rh not in [0,1])
+    if (rh < -eps_zero || rh > 1.0 + eps_zero) {
+        throw std::range_error("Thrown in water_vapor_properties_from_air_temperature: rh does not lie in the interval [0, 1].");
+    }
+
+    // Collect input quantities and make calculations
     double density_of_dry_air = TempToDdryA(temp);                             // kg / m^3
     double latent_heat_vaporization_of_water = TempToLHV(temp);                // J / kg
     double saturation_water_vapor_pressure = saturation_vapor_pressure(temp);  // Pa

--- a/tests/testthat/test.relative_humidity.R
+++ b/tests/testthat/test.relative_humidity.R
@@ -31,3 +31,22 @@ for (cn in all_rh_column_names) {
         )
     })
 }
+
+# Make sure bad RH values are caught
+test_that('Bad RH values are caught', {
+    bad_weather <- soybean_weather[['2004']]
+    bad_weather$rh <- bad_weather$rh * 100
+
+    expect_error(
+        with(soybean, {run_biocro(
+            initial_values,
+            parameters,
+            bad_weather,
+            direct_modules,
+            differential_modules,
+            ode_solver
+        )}),
+        'rh does not lie in the interval [0, 1]',
+        fixed = TRUE
+    )
+})


### PR DESCRIPTION
This PR adds some checks to make sure RH is not expressed as a percentage, since that can cause calculation issues. See this comment for more information: https://github.com/biocro/biocro/issues/344#issuecomment-5592169144

To address this, I got a list of all modules that take `rh` as an input. Many of them use either `ball_berry_gs`, `leaf_energy_balance`, or both, so adding checks to these functions cover several modules:
- `BioCro:ball_berry`
- `BioCro:c3_assimilation`
- `BioCro:c3_canopy`
- `BioCro:c3_leaf_photosynthesis`
- `BioCro:c4_assimilation`
- `BioCro:c4_canopy`
- `BioCro:c4_leaf_photosynthesis`
- `BioCro:ten_layer_c3_canopy`
- `BioCro:ten_layer_c4_canopy`
- `BioCro:leaf_evapotranspiration`
- `BioCro:leaf_evapotranspiration_check`

Then there were a few others that needed separate checks:
- `BioCro:leaf_gbw_nikolov`
- `BioCro:rh_to_mole_fraction`
- `BioCro:soil_evaporation`
- `BioCro:soil_evaporation_ritchie`
- `BioCro:two_layer_soil_profile`
- `BioCro:water_vapor_properties_from_air_temperature`