### PR TITLE
Change minimum supported R version to 4.2.0

### DIFF
--- a/.github/workflows/R-CMD-check-changes-meaning.yaml
+++ b/.github/workflows/R-CMD-check-changes-meaning.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           inputFile: '.github/workflows/strategy_matrix.json'
           filter:
-            '[?configName == ''R 4.1.0 on Ubuntu''
+            '[?configName == ''R 4.2.0 on Ubuntu''
                 || configName == ''R release version on Ubuntu''
                 || configName == ''R devel version on Ubuntu'']'
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -56,15 +56,15 @@ on:
         description: 'Platform to check'
         type: choice
         options:
-          - R 4.1.0 on Ubuntu
+          - R 4.2.0 on Ubuntu
           - R release version on Ubuntu
           - R devel version on Ubuntu
           - R 4.3.0 on macOS
           - R release version on macOS
-          - R 4.1.0 on Windows
+          - R 4.2.0 on Windows
           - R release version on Windows
           - R devel version on Windows
-        default: R 4.1.0 on Ubuntu
+        default: R 4.2.0 on Ubuntu
 
 jobs:
 

--- a/.github/workflows/strategy_matrix.json
+++ b/.github/workflows/strategy_matrix.json
@@ -1,8 +1,8 @@
 [
     {
-        "configName": "R 4.1.0 on Windows",
+        "configName": "R 4.2.0 on Windows",
         "os": "windows-latest",
-        "r": "4.1.0"
+        "r": "4.2.0"
     },
     {
         "configName": "R 4.3.0 on macOS",
@@ -10,9 +10,9 @@
         "r": "4.3.0"
     },
     {
-        "configName": "R 4.1.0 on Ubuntu",
+        "configName": "R 4.2.0 on Ubuntu",
         "os": "ubuntu-24.04",
-        "r": "4.1.0"
+        "r": "4.2.0"
     },
     {
         "configName": "R release version on Ubuntu",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: BioCro
-Version: 3.4.0
+Version: 3.4.0-1
 Date: 2026-08-20
 Title: Modular Crop Growth Simulations
 Description: A cross-platform representation of models as sets of equations
@@ -34,7 +34,7 @@ Authors@R: c(
     person("Boost Organization", role = "cph",
            comment = "Copyright holder of included Boost library")
     )
-Depends: R (>= 4.1.0)
+Depends: R (>= 4.2.0)
 Imports:
     stats
 Suggests:

--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,17 @@ In the case of a hotfix, a short section headed by the new release number should
 be directly added to this file to describe the related changes.
 -->
 
+# UNRELEASED
+
+## Bug Fixes
+
+- Changed the minimum required version of R from 4.1.0 to 4.2.0.
+
+  - Somehow the vignette builder cannot find the `knitr` package when using the
+    the online testing setup for R version 4.1.0 on Windows, even when `knitr`
+    is installed, causing a spurious test failure. This problem does not occur
+    for R version 4.2.0.
+
 # Changes in BioCro version 3.4.0
 
 ## Minor User-Facing Changes
@@ -132,8 +143,8 @@ be directly added to this file to describe the related changes.
 
 ## Bug Fixes
 
-- Changed the minimum version of macOS checked by the R-CMD-check from
-  4.2.0 to 4.3.0.
+- Changed the minimum version of R checked by the R-CMD-check workflow for MacOS
+  from 4.2.0 to 4.3.0.
 
   - CRAN now only provides R versions 4.2.3 and above for Mac.
 


### PR DESCRIPTION
Changing the minimum required version of R from 4.1.0 to 4.2.0 seems to solve the problem discussed in this previous PR: https://github.com/biocro/biocro/pull/349